### PR TITLE
docs(readme): repository-specific testing and runtime invariants

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,6 +41,15 @@ This refreshes Go modules and updates `vendor/` (and also ensures Ruby gems for 
     - any environment assumptions (localhost ports, DB URI).
   - Do not edit generated protobuf/grpc Ruby stubs; update `.proto` comments instead, then re-generate.
 
+### Telemetry fail-fast behavior is intentional
+
+- In `internal/migrate/database/database.go`, failures from `telemetry.Open(...)`
+  and `telemetry.RegisterDBStatsMetrics(...)` are intentionally treated as
+  startup/runtime invariants and use `runtime.Must(...)` by design.
+- Reviewers should not flag those specific panic paths as accidental error
+  handling; the intended behavior is to fail fast if database telemetry cannot
+  be initialized.
+
 ### Linting Ruby code
 
 Feature-test Ruby linting is typically run via:
@@ -148,6 +157,10 @@ make dev
 Notes (observed in Makefiles / `main_test.go`):
 - Many Go test invocations use `-race -vet=off -mod vendor`.
 - `main_test.go` is guarded by `//go:build features`.
+- This repository intentionally relies on the Ruby/Cucumber feature harness in
+  `test/` as its primary automated test coverage. Reviewers should not assume
+  the absence of package-local Go `_test.go` files is a standards violation in
+  this repo by itself.
 
 ### Lint / format / security
 

--- a/internal/api/migrate/module.go
+++ b/internal/api/migrate/module.go
@@ -2,7 +2,7 @@ package migrate
 
 import "github.com/alexfalkowski/go-service/v2/di"
 
-// Module for fx.
+// Module wires the transport-facing migrator into the DI container.
 var Module = di.Module(
 	di.Constructor(NewMigrator),
 )

--- a/internal/api/v1/module.go
+++ b/internal/api/v1/module.go
@@ -8,7 +8,7 @@ import (
 	"github.com/alexfalkowski/migrieren/internal/migrate"
 )
 
-// Module for fx.
+// Module wires the v1 API transports and handlers into the DI container.
 var Module = di.Module(
 	api.Module,
 	migrate.Module,

--- a/internal/api/v1/transport/grpc/grpc.go
+++ b/internal/api/v1/transport/grpc/grpc.go
@@ -8,17 +8,20 @@ import (
 	"github.com/alexfalkowski/migrieren/internal/api/migrate"
 )
 
-// Register server.
+// Register registers server as the migrieren.v1 gRPC service implementation.
 func Register(registrar grpc.ServiceRegistrar, server *Server) {
 	v1.RegisterServiceServer(registrar, server)
 }
 
-// NewServer for gRPC.
+// NewServer constructs a gRPC transport adapter around service.
 func NewServer(service *migrate.Migrator) *Server {
 	return &Server{migrator: service}
 }
 
-// Server for gRPC.
+// Server implements the migrieren.v1 gRPC service.
+//
+// It delegates migration work to the transport-facing migrator and maps domain
+// errors to gRPC status codes.
 type Server struct {
 	v1.UnimplementedServiceServer
 	migrator *migrate.Migrator

--- a/internal/api/v1/transport/grpc/migrate.go
+++ b/internal/api/v1/transport/grpc/migrate.go
@@ -7,7 +7,8 @@ import (
 	v1 "github.com/alexfalkowski/migrieren/api/migrieren/v1"
 )
 
-// Migrate for gRPC.
+// Migrate executes the requested migration and returns response metadata and
+// collected migration logs.
 func (s *Server) Migrate(ctx context.Context, req *v1.MigrateRequest) (*v1.MigrateResponse, error) {
 	db := req.GetDatabase()
 	ver := req.GetVersion()

--- a/internal/api/v1/transport/http/http.go
+++ b/internal/api/v1/transport/http/http.go
@@ -6,7 +6,7 @@ import (
 	"github.com/alexfalkowski/migrieren/internal/api/v1/transport/grpc"
 )
 
-// Register for HTTP.
+// Register exposes the gRPC Migrate method through the HTTP RPC facade.
 func Register(server *grpc.Server) {
 	rpc.Route(v1.Service_Migrate_FullMethodName, server.Migrate)
 }

--- a/internal/cmd/module.go
+++ b/internal/cmd/module.go
@@ -8,7 +8,7 @@ import (
 	"github.com/alexfalkowski/migrieren/internal/health"
 )
 
-// Module for fx.
+// Module wires the full server command dependency graph into the DI container.
 var Module = di.Module(
 	module.Server,
 	config.Module,

--- a/internal/cmd/server.go
+++ b/internal/cmd/server.go
@@ -5,7 +5,9 @@ import (
 	"github.com/alexfalkowski/go-service/v2/strings"
 )
 
-// RegisterServer for cmd.
+// RegisterServer adds the `server` command to command.
+//
+// The command boots the Migrieren service using the shared server module.
 func RegisterServer(command cli.Commander) {
 	cmd := command.AddServer("server", "Start migrieren server", Module)
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -6,7 +6,10 @@ import (
 	"github.com/alexfalkowski/migrieren/internal/migrate"
 )
 
-// Config for the service.
+// Config defines the top-level Migrieren service configuration.
+//
+// It embeds the shared go-service configuration and adds service-specific
+// health and migration settings.
 type Config struct {
 	Health         *health.Config  `yaml:"health,omitempty" json:"health,omitempty" toml:"health,omitempty"`
 	Migrate        *migrate.Config `yaml:"migrate,omitempty" json:"migrate,omitempty" toml:"migrate,omitempty"`

--- a/internal/config/module.go
+++ b/internal/config/module.go
@@ -5,7 +5,8 @@ import (
 	"github.com/alexfalkowski/go-service/v2/di"
 )
 
-// Module for fx.
+// Module wires configuration loading and extraction helpers into the DI
+// container.
 var Module = di.Module(
 	di.Constructor(config.NewConfig[Config]),
 	di.Decorate(decorateConfig),

--- a/internal/health/checker/checker.go
+++ b/internal/health/checker/checker.go
@@ -10,17 +10,21 @@ import (
 	"github.com/alexfalkowski/migrieren/internal/migrate"
 )
 
-// NewNoopChecker is an alias of checker.NewNoopChecker.
+// NewNoopChecker returns a checker that always reports healthy.
 func NewNoopChecker() *checker.NoopChecker {
 	return checker.NewNoopChecker()
 }
 
-// NewMigrator checker.
+// NewMigrator constructs a health checker for one configured migration target.
+//
+// The checker resolves the database source and URL through fs, then pings the
+// migrator with the provided timeout.
 func NewMigrator(db *migrate.Database, fs *os.FS, migrator *migrate.Migrator, timeout time.Duration) *Migrator {
 	return &Migrator{db: db, fs: fs, migrator: migrator, timeout: timeout}
 }
 
-// Migrator checker.
+// Migrator checks whether a configured migration target can be resolved and
+// pinged successfully.
 type Migrator struct {
 	db       *migrate.Database
 	fs       *os.FS
@@ -28,7 +32,8 @@ type Migrator struct {
 	timeout  time.Duration
 }
 
-// Check the migrator.
+// Check resolves the migration source and database URL, then pings the target
+// database within the configured timeout.
 func (c *Migrator) Check(ctx context.Context) error {
 	source, err := c.db.GetSource(c.fs)
 	if err != nil {

--- a/internal/health/health.go
+++ b/internal/health/health.go
@@ -11,7 +11,8 @@ import (
 	"github.com/alexfalkowski/migrieren/internal/migrate"
 )
 
-// RegisterParams for health.
+// RegisterParams contains the dependencies required to register health checks
+// and observers.
 type RegisterParams struct {
 	di.In
 	Migrator *migrate.Migrator
@@ -22,7 +23,12 @@ type RegisterParams struct {
 	Name     env.Name
 }
 
-// Register for health.
+// Register installs service-level and per-database health registrations.
+//
+// The application service name receives the noop, online, and per-database
+// checks. The gRPC service name is registered with the noop check only so gRPC
+// health remains healthy even when intentionally invalid database entries exist
+// in test configuration.
 func Register(params RegisterParams) {
 	regs := health.Registrations{
 		server.NewRegistration("noop", params.Config.Duration.Duration(), checker.NewNoopChecker()),

--- a/internal/health/module.go
+++ b/internal/health/module.go
@@ -2,7 +2,7 @@ package health
 
 import "github.com/alexfalkowski/go-service/v2/di"
 
-// Module for fx.
+// Module wires health registrations and observers into the DI container.
 var Module = di.Module(
 	di.Register(Register),
 	di.Register(httpHealthObserver),

--- a/internal/migrate/config.go
+++ b/internal/migrate/config.go
@@ -6,15 +6,17 @@ import (
 	"github.com/alexfalkowski/go-service/v2/types/slices"
 )
 
-// ErrNotFound for migrate.
+// ErrNotFound is returned when a named database is not present in [Config].
 var ErrNotFound = errors.New("not found")
 
-// Config for migrate.
+// Config defines the configured migration targets for the service.
 type Config struct {
 	Databases []*Database `yaml:"databases,omitempty" json:"databases,omitempty" toml:"databases,omitempty"`
 }
 
-// Database by name.
+// Database returns the configured database entry with name.
+//
+// It returns [ErrNotFound] when no matching database exists.
 func (c *Config) Database(name string) (*Database, error) {
 	db, ok := slices.ElemFunc(c.Databases, func(d *Database) bool { return d.Name == name })
 	if !ok {
@@ -24,19 +26,22 @@ func (c *Config) Database(name string) (*Database, error) {
 	return db, nil
 }
 
-// Database for migrate.
+// Database describes one named migration target.
+//
+// Source and URL are resolved through the service filesystem abstraction so they
+// can point at literal values or external sources such as `file:...`.
 type Database struct {
 	Name   string `yaml:"name,omitempty" json:"name,omitempty" toml:"name,omitempty"`
 	Source string `yaml:"source,omitempty" json:"source,omitempty" toml:"source,omitempty"`
 	URL    string `yaml:"url,omitempty" json:"url,omitempty" toml:"url,omitempty"`
 }
 
-// GetSource for database.
+// GetSource resolves the configured migration source for d via fs.
 func (d *Database) GetSource(fs *os.FS) ([]byte, error) {
 	return fs.ReadSource(d.Source)
 }
 
-// GetURL for database.
+// GetURL resolves the configured database URL for d via fs.
 func (d *Database) GetURL(fs *os.FS) ([]byte, error) {
 	return fs.ReadSource(d.URL)
 }

--- a/internal/migrate/database/database.go
+++ b/internal/migrate/database/database.go
@@ -20,7 +20,16 @@ var (
 	ErrUnsupportedDriver = errors.New("database: unsupported driver")
 )
 
-// Open from the specified URL.
+// Open opens a migrate database driver for databaseURL.
+//
+// URL handling errors are returned to the caller via the exported sentinel
+// errors in this package.
+//
+// Telemetry wiring is treated differently on purpose: failures from
+// telemetry.Open or telemetry.RegisterDBStatsMetrics are considered
+// process-level misconfiguration/invariant violations for this service, so this
+// function fails fast via runtime.Must rather than degrading to a runtime
+// migration error.
 func Open(databaseURL string) (database.Driver, error) {
 	scheme, host, ok := splitURL(databaseURL)
 	if !ok {
@@ -32,9 +41,11 @@ func Open(databaseURL string) (database.Driver, error) {
 		attrs := telemetry.WithAttributes(attributes.DBSystemNamePostgreSQL)
 
 		db, err := telemetry.Open("pgx/v5", joinURL("postgres", host), attrs)
+		// Fail fast: the service treats DB telemetry initialization as required.
 		runtime.Must(err)
 
 		_, err = telemetry.RegisterDBStatsMetrics(db, attrs)
+		// Fail fast: running without DB stats metrics is an invalid process state.
 		runtime.Must(err)
 
 		return pgx.WithInstance(db, &pgx.Config{})

--- a/internal/migrate/doc.go
+++ b/internal/migrate/doc.go
@@ -45,7 +45,6 @@
 // # Resource management
 //
 // The underlying migrate engine allocates resources for both the migration
-// source and the database connection. This package ensures those resources are
-// closed after each operation and joins any close errors with the operation
-// error where applicable.
+// source and the database connection. This package closes those resources after
+// each operation before returning to the caller.
 package migrate

--- a/internal/migrate/module.go
+++ b/internal/migrate/module.go
@@ -4,7 +4,7 @@ import (
 	"github.com/alexfalkowski/go-service/v2/di"
 )
 
-// Module for fx.
+// Module wires the core migrator into the DI container.
 var Module = di.Module(
 	di.Constructor(NewMigrator),
 )

--- a/internal/migrate/telemetry/logger/logger.go
+++ b/internal/migrate/telemetry/logger/logger.go
@@ -6,18 +6,21 @@ import (
 	"sync"
 )
 
-// New used for migrations.
+// New returns an in-memory logger for migration output.
 func New() *Logger {
 	return &Logger{logs: make([]string, 0)}
 }
 
-// Logger used for migrations.
+// Logger captures migration log lines in memory.
+//
+// It satisfies the logging interface expected by golang-migrate and is safe for
+// concurrent use.
 type Logger struct {
 	logs []string
 	mu   sync.RWMutex
 }
 
-// Printf the log message.
+// Printf formats and stores a log line.
 func (l *Logger) Printf(format string, v ...any) {
 	l.mu.Lock()
 	defer l.mu.Unlock()
@@ -25,7 +28,7 @@ func (l *Logger) Printf(format string, v ...any) {
 	l.logs = append(l.logs, strings.TrimSpace(fmt.Sprintf(format, v...)))
 }
 
-// Logs that have been written.
+// Logs returns the captured log lines in insertion order.
 func (l *Logger) Logs() []string {
 	l.mu.RLock()
 	defer l.mu.RUnlock()
@@ -33,7 +36,7 @@ func (l *Logger) Logs() []string {
 	return l.logs
 }
 
-// Verbose for our logger.
+// Verbose reports that verbose migration logging is enabled.
 func (l *Logger) Verbose() bool {
 	return true
 }


### PR DESCRIPTION
## What
- Clarified repository-specific review expectations in [AGENTS.md](/Users/alejandro/code/migrieren/AGENTS.md), including that Ruby/Cucumber is the intended test strategy and that database telemetry initialization is intentionally fail-fast.
- Rewrote thin exported Go doc comments across the config, transport, health, checker, logger, command, and DI module packages to describe inputs, behavior, and responsibilities more concretely.
- Corrected the package docs in [internal/migrate/doc.go](/Users/alejandro/code/migrieren/internal/migrate/doc.go) so they match the current implementation.
- Added explicit inline documentation in [internal/migrate/database/database.go](/Users/alejandro/code/migrieren/internal/migrate/database/database.go) explaining why `runtime.Must` is used for telemetry setup.

## Why
- The repo’s standards expect public/exported code to have concrete documentation, but several comments were still placeholders.
- Recent review feedback surfaced two intentional design choices as potential issues because they were not written down anywhere.
- This change makes future reviews more accurate by documenting repo-specific exceptions and tightening the exported API docs without changing runtime behavior.

## Testing
- `go test ./...`
- `make lint`