### PR TITLE
feat(deps): upgraded github.com/alexfalkowski/go-service/v2 to v2.386.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.26.0
 
 require (
 	github.com/alexfalkowski/go-health/v2 v2.19.2
-	github.com/alexfalkowski/go-service/v2 v2.385.0
+	github.com/alexfalkowski/go-service/v2 v2.386.0
 	github.com/golang-migrate/migrate/v4 v4.19.1
 	github.com/jackc/pgx/v5 v5.9.2
 	google.golang.org/grpc v1.81.0

--- a/go.sum
+++ b/go.sum
@@ -21,8 +21,8 @@ github.com/aead/cmac v0.0.0-20160719120800-7af84192f0b1 h1:+JkXLHME8vLJafGhOH4ao
 github.com/aead/cmac v0.0.0-20160719120800-7af84192f0b1/go.mod h1:nuudZmJhzWtx2212z+pkuy7B6nkBqa+xwNXZHL1j8cg=
 github.com/alexfalkowski/go-health/v2 v2.19.2 h1:wsqGEevu5mF0+/3QNABgB7R2gpGk4j9fwuMtbzIVzuo=
 github.com/alexfalkowski/go-health/v2 v2.19.2/go.mod h1:ypy+lqZpEh2HPNLqaDAv6wJBbxuouOZoPkkrtrMNXrA=
-github.com/alexfalkowski/go-service/v2 v2.385.0 h1:aBqoxLCmBZXmisoBmQm371TSPqFeFZuUceq4qJfzcgI=
-github.com/alexfalkowski/go-service/v2 v2.385.0/go.mod h1:wIptQ3a925U+KkaBY0hqR2M72fnMeN9F2cGBdiaBsRE=
+github.com/alexfalkowski/go-service/v2 v2.386.0 h1:ES9JnMkx1a0cvc9MWWV+NNj/gAZn5qcOui7K+MhLgz4=
+github.com/alexfalkowski/go-service/v2 v2.386.0/go.mod h1:wIptQ3a925U+KkaBY0hqR2M72fnMeN9F2cGBdiaBsRE=
 github.com/alexfalkowski/go-sync v1.21.0 h1:Aydt3mB0FwmaRPjDsO4ZHJIa0HdueTwRt0i4NQtNvsA=
 github.com/alexfalkowski/go-sync v1.21.0/go.mod h1:J2yBCIWJ1YAWqAJ94Bt2xroR2rOWlSyRBGqqNJDmLBw=
 github.com/arl/statsviz v0.8.0 h1:O6GjjVxEDxcByAucOSl29HaGYLXsuwA3ujJw8H9E7/U=

--- a/test/Gemfile.lock
+++ b/test/Gemfile.lock
@@ -142,7 +142,7 @@ GEM
     rspec-support (3.13.7)
     rspec-wait (1.0.2)
       rspec (>= 3.4)
-    rubocop (1.86.1)
+    rubocop (1.86.2)
       json (~> 2.3)
       language_server-protocol (~> 3.17.0.2)
       lint_roller (~> 1.1.0)


### PR DESCRIPTION
https://github.com/alexfalkowski/go-service/releases/tag/v2.386.0
