### PR TITLE
feat(database): unregister stats metrics on close

### DIFF
--- a/internal/migrate/database/database.go
+++ b/internal/migrate/database/database.go
@@ -10,6 +10,7 @@ import (
 	"github.com/golang-migrate/migrate/v4/database"
 	"github.com/golang-migrate/migrate/v4/database/pgx/v5"
 	_ "github.com/jackc/pgx/v5"
+	"go.opentelemetry.io/otel/metric"
 )
 
 var (
@@ -44,14 +45,31 @@ func Open(databaseURL string) (database.Driver, error) {
 		// Fail fast: the service treats DB telemetry initialization as required.
 		runtime.Must(err)
 
-		_, err = telemetry.RegisterDBStatsMetrics(db, attrs)
+		reg, err := telemetry.RegisterDBStatsMetrics(db, attrs)
 		// Fail fast: running without DB stats metrics is an invalid process state.
 		runtime.Must(err)
 
-		return pgx.WithInstance(db, &pgx.Config{})
+		dbDriver, err := pgx.WithInstance(db, &pgx.Config{})
+		if err != nil {
+			_ = reg.Unregister()
+			_ = db.Close()
+
+			return nil, err
+		}
+
+		return &instrumentedDriver{Driver: dbDriver, registration: reg}, nil
 	default:
 		return nil, ErrUnsupportedDriver
 	}
+}
+
+type instrumentedDriver struct {
+	database.Driver
+	registration metric.Registration
+}
+
+func (d *instrumentedDriver) Close() error {
+	return errors.Join(d.Driver.Close(), d.registration.Unregister())
 }
 
 func splitURL(url string) (string, string, bool) {


### PR DESCRIPTION
## What
- Capture the OpenTelemetry DB stats metric registration created for pgx migration drivers.
- Wrap the migrate database driver so Close also unregisters the stats callback.
- Clean up the registration and SQL DB handle if pgx driver construction fails.

## Why
- Migration and health ping operations open short-lived migrate drivers, so metric callbacks need to follow the same lifecycle.
- This prevents stale DB stats callbacks from accumulating after each operation.

## Testing
- `go test ./...`
- `gmake lint` reached Go lint with 0 issues, then failed in Ruby lint because Bundler 4.0.11 is not installed locally.
