### PR TITLE
feat(checker): return ping deadline errors promptly

### DIFF
--- a/internal/health/checker/checker.go
+++ b/internal/health/checker/checker.go
@@ -48,7 +48,16 @@ func (c *Migrator) Check(ctx context.Context) error {
 	ctx, cancel := context.WithTimeout(ctx, c.timeout.Duration())
 	defer cancel()
 
-	_, err = c.migrator.Ping(ctx, bytes.String(source), bytes.String(url))
+	errCh := make(chan error, 1)
+	go func() {
+		_, err := c.migrator.Ping(ctx, bytes.String(source), bytes.String(url))
+		errCh <- err
+	}()
 
-	return err
+	select {
+	case err := <-errCh:
+		return err
+	case <-ctx.Done():
+		return ctx.Err()
+	}
 }


### PR DESCRIPTION
## What
- Run migrator health pings asynchronously within the checker timeout window.
- Return the ping result when it finishes first, or the context deadline error when the checker timeout wins.

## Why
- Health checks should report their configured timeout promptly even if the underlying ping finishes later.
- This keeps migration execution behavior unchanged while making health probe timing deterministic.

## Testing
- `go test ./internal/health/checker`
- `go test ./...`
- `gmake lint` reached Go lint with 0 issues, then failed in Ruby lint because Bundler 4.0.11 is not installed locally.
