### PR TITLE
feat(health): require positive probe timing

### DIFF
--- a/internal/health/config.go
+++ b/internal/health/config.go
@@ -2,14 +2,6 @@ package health
 
 import "github.com/alexfalkowski/go-service/v2/time"
 
-const (
-	// DefaultDuration is used when health.duration is omitted or non-positive.
-	DefaultDuration = time.Second
-
-	// DefaultTimeout is used when health.timeout is omitted or non-positive.
-	DefaultTimeout = time.Second
-)
-
 // Config defines health check timing configuration.
 //
 // Duration and Timeout are duration strings (for example "5s", "1m") that are
@@ -18,24 +10,6 @@ const (
 // Duration controls how often health registrations are evaluated/updated.
 // Timeout is reserved for probe/check timeout configuration.
 type Config struct {
-	Duration time.Duration `yaml:"duration,omitempty" json:"duration,omitempty" toml:"duration,omitempty"`
-	Timeout  time.Duration `yaml:"timeout,omitempty" json:"timeout,omitempty" toml:"timeout,omitempty"`
-}
-
-// GetDuration returns the configured health check duration or a default.
-func (c *Config) GetDuration() time.Duration {
-	if c.Duration > 0 {
-		return c.Duration
-	}
-
-	return DefaultDuration
-}
-
-// GetTimeout returns the configured health check timeout or a default.
-func (c *Config) GetTimeout() time.Duration {
-	if c.Timeout > 0 {
-		return c.Timeout
-	}
-
-	return DefaultTimeout
+	Duration time.Duration `yaml:"duration,omitempty" json:"duration,omitempty" toml:"duration,omitempty" validate:"gt=0"`
+	Timeout  time.Duration `yaml:"timeout,omitempty" json:"timeout,omitempty" toml:"timeout,omitempty" validate:"gt=0"`
 }

--- a/internal/health/health.go
+++ b/internal/health/health.go
@@ -30,17 +30,14 @@ type RegisterParams struct {
 // health remains healthy even when intentionally invalid database entries exist
 // in test configuration.
 func Register(params RegisterParams) {
-	duration := params.Config.GetDuration()
-	timeout := params.Config.GetTimeout()
-
 	regs := health.Registrations{
-		server.NewRegistration("noop", duration.Duration(), checker.NewNoopChecker()),
-		server.NewOnlineRegistration(timeout.Duration(), duration.Duration()),
+		server.NewRegistration("noop", params.Config.Duration.Duration(), checker.NewNoopChecker()),
+		server.NewOnlineRegistration(params.Config.Timeout.Duration(), params.Config.Duration.Duration()),
 	}
 
 	for _, db := range params.Migrate.Databases {
-		checker := checker.NewMigrator(db, params.FS, params.Migrator, timeout)
-		reg := server.NewRegistration(db.Name, duration.Duration(), checker)
+		checker := checker.NewMigrator(db, params.FS, params.Migrator, params.Config.Timeout)
+		reg := server.NewRegistration(db.Name, params.Config.Duration.Duration(), checker)
 		regs = append(regs, reg)
 	}
 


### PR DESCRIPTION
## What

- Require positive probe duration and timeout values with config validation tags.
- Remove health timing default accessors now that runtime config sections are required.
- Use the validated timing values directly when registering health probes.

## Why

- Zero or omitted probe timing should fail config validation instead of being silently defaulted.
- Keeping timing requirements in validation matches the required top-level config contract.
- No blocking code-review findings were found.

## Testing

- `git diff --check` - passed
- `go test ./internal/health ./internal/config ./internal/cmd` - passed
- `make lint` - passed
- `make -C test features feature=features/health/transport/http/observability.feature` - passed after rerun

AI-assisted-by: [Codex](https://openai.com/codex/)
