### PR TITLE
test(observability): wait for health status transitions

### DIFF
--- a/test/features/step_definitions/health/transport/http/observability_steps.rb
+++ b/test/features/step_definitions/health/transport/http/observability_steps.rb
@@ -1,24 +1,30 @@
 # frozen_string_literal: true
 
 When('the system requests the {string} with HTTP') do |name|
-  opts = {
+  @observability_name = name
+  @observability_opts = {
     headers: { request_id: SecureRandom.uuid },
     read_timeout: 10, open_timeout: 10
   }
-
-  @response = Nonnative.observability.send(name, opts)
 end
 
 Then('the system should respond with a healthy status with HTTP') do
-  expect(@response.code).to eq(200)
-  expect(@response.body.strip).to eq('SERVING')
+  wait_for do
+    response = Nonnative.observability.send(@observability_name, @observability_opts)
+    [response.code, response.body.strip]
+  end.to eq([200, 'SERVING'])
 end
 
 Then('the system should respond with an unhealthy status with HTTP') do
-  expect(@response.code).to eq(503)
+  wait_for do
+    response = Nonnative.observability.send(@observability_name, @observability_opts)
+    response.code
+  end.to eq(503)
 end
 
 Then('the system should respond with metrics') do
-  expect(@response.code).to eq(200)
-  expect(@response.body).to include('go_info')
+  response = Nonnative.observability.send(@observability_name, @observability_opts)
+
+  expect(response.code).to eq(200)
+  expect(response.body).to include('go_info')
 end


### PR DESCRIPTION
## What

- Store HTTP observability request details in the When step and issue the actual request from each assertion step.
- Use wait_for around health status assertions so asynchronous health state can settle before checking status and body.

## Why

- Prevent intermittent HTTP health assertions from reading the initial transient healthy observer state before failing database checks are observed.

## Testing

- `ruby -c test/features/step_definitions/health/transport/http/observability_steps.rb` - passed
- `git diff --check` - passed
- `make -C test lint` - passed
- `make features` - passed
