### PR TITLE
test(feature): verify migration effects

### DIFF
--- a/test/features/step_definitions/v1/transport/grpc/api_steps.rb
+++ b/test/features/step_definitions/v1/transport/grpc/api_steps.rb
@@ -11,6 +11,8 @@ Then('I should receive a successful migration from gRPC:') do |table|
   expect(@response.migration.database).to eq(rows['database'])
   expect(@response.migration.version).to eq(rows['version'].to_i)
   expect(@response.migration.logs.length).to be >= 0
+
+  expect_postgres_migration(rows['version'].to_i) if rows['database'] == 'postgres'
 end
 
 Then('I should receive a not found migration from gRPC') do

--- a/test/features/step_definitions/v1/transport/http/api_steps.rb
+++ b/test/features/step_definitions/v1/transport/http/api_steps.rb
@@ -16,6 +16,8 @@ Then('I should receive a successful migration from HTTP:') do |table|
   expect(migration['database']).to eq(rows['database'])
   expect(migration['version']).to eq(rows['version'].to_i)
   expect(logs.length).to be >= 0
+
+  expect_postgres_migration(rows['version'].to_i) if rows['database'] == 'postgres'
 end
 
 Then('I should receive a not found migration from HTTP') do

--- a/test/features/step_definitions/v1/transport/http/benchmark_steps.rb
+++ b/test/features/step_definitions/v1/transport/http/benchmark_steps.rb
@@ -9,5 +9,9 @@ When('I request to migrate with HTTP which performs in {int} ms') do |time|
     read_timeout: 10, open_timeout: 10
   }
 
-  expect { Migrieren::V1.server_http.migrate('postgres', rand(1..2), opts) }.to perform_under(time).ms
+  expect do
+    response = Migrieren::V1.server_http.migrate('postgres', rand(1..2), opts)
+
+    expect(response.code).to eq(200)
+  end.to perform_under(time).ms
 end

--- a/test/features/step_definitions/v1/transport/migration_steps.rb
+++ b/test/features/step_definitions/v1/transport/migration_steps.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+def expect_postgres_migration(version)
+  expect_postgres_migration_table(version)
+  expect_postgres_accounts(version)
+end
+
+def expect_postgres_migration_table(version)
+  expect(Migrieren.pg.table?('schema_migrations')).to be(false)
+  expect(Migrieren.pg.table?('migrieren_schema_migrations')).to be(true)
+  expect(Migrieren.pg.migration_version).to eq(version)
+end
+
+def expect_postgres_accounts(version)
+  expect(Migrieren.pg.table?('accounts')).to be(true)
+  expect(Migrieren.pg.account_count).to be > 0
+  expect(Migrieren.pg.column?('accounts', 'update_at')).to eq(version == 2)
+end

--- a/test/features/support/nonnative.rb
+++ b/test/features/support/nonnative.rb
@@ -5,9 +5,17 @@ Nonnative.configure do |config|
 end
 
 BeforeAll do
-  Migrieren.pg.destroy
+  Migrieren.pg.verify_destroy
+  expect_destroyed_database
 end
 
 After('@clean') do
   Migrieren.pg.destroy
+  expect_destroyed_database
+end
+
+def expect_destroyed_database
+  return if Migrieren.pg.destroyed?
+
+  raise 'expected Migrieren.pg.destroy to remove managed tables'
 end

--- a/test/lib/migrieren/pg.rb
+++ b/test/lib/migrieren/pg.rb
@@ -47,5 +47,81 @@ module Migrieren
       @conn.exec('DROP TABLE IF EXISTS schema_migrations')
       @conn.exec('DROP TABLE IF EXISTS migrieren_schema_migrations')
     end
+
+    ##
+    # Seeds the managed tables, then runs {#destroy}.
+    #
+    # This verifies the cleanup path from the feature harness without modeling it
+    # as an application feature.
+    #
+    # @return [void]
+    def verify_destroy
+      @conn.exec('CREATE TABLE IF NOT EXISTS accounts (user_id serial PRIMARY KEY)')
+      @conn.exec('CREATE TABLE IF NOT EXISTS schema_migrations (version bigint NOT NULL)')
+      @conn.exec('CREATE TABLE IF NOT EXISTS migrieren_schema_migrations (version bigint NOT NULL)')
+
+      destroy
+    end
+
+    ##
+    # Checks whether all tables managed by {#destroy} are absent.
+    #
+    # @return [Boolean] true when cleanup left no managed tables behind
+    def destroyed?
+      !table?('accounts') && !table?('schema_migrations') && !table?('migrieren_schema_migrations')
+    end
+
+    ##
+    # Checks whether a table exists in the public schema.
+    #
+    # @param name [String] table name
+    # @return [Boolean] true when the table exists
+    def table?(name)
+      query = <<~SQL
+        SELECT EXISTS (
+          SELECT 1
+          FROM information_schema.tables
+          WHERE table_schema = 'public' AND table_name = $1
+        )
+      SQL
+
+      @conn.exec_params(query, [name]).getvalue(0, 0) == 't'
+    end
+
+    ##
+    # Checks whether a column exists on a table in the public schema.
+    #
+    # @param table [String] table name
+    # @param column [String] column name
+    # @return [Boolean] true when the column exists
+    def column?(table, column)
+      query = <<~SQL
+        SELECT EXISTS (
+          SELECT 1
+          FROM information_schema.columns
+          WHERE table_schema = 'public' AND table_name = $1 AND column_name = $2
+        )
+      SQL
+
+      @conn.exec_params(query, [table, column]).getvalue(0, 0) == 't'
+    end
+
+    ##
+    # Returns the number of rows in the accounts fixture table.
+    #
+    # @return [Integer] row count
+    def account_count
+      @conn.exec('SELECT COUNT(*) FROM accounts').getvalue(0, 0).to_i
+    end
+
+    ##
+    # Returns the current clean migration version from the configured migration table.
+    #
+    # @return [Integer, nil] the version, or nil when the table has no row
+    def migration_version
+      result = @conn.exec('SELECT version FROM migrieren_schema_migrations WHERE dirty = false LIMIT 1')
+
+      result.ntuples.zero? ? nil : result.getvalue(0, 0).to_i
+    end
   end
 end

--- a/test/migrations/0001_accounts.up.sql
+++ b/test/migrations/0001_accounts.up.sql
@@ -2,3 +2,4 @@ CREATE TABLE accounts (
 	user_id serial PRIMARY KEY,
 	created_at TIMESTAMP NOT NULL
 );
+INSERT INTO accounts (created_at) VALUES (NOW());


### PR DESCRIPTION
## What

- Add Postgres harness helpers that assert migration tables, schema columns, row counts, and cleanup state.
- Assert local Postgres migration effects from both HTTP and gRPC success paths.
- Exercise multi-statement migration handling with a fixture insert.
- Make the HTTP benchmark fail when the migration response is not successful.

## Why

- Protect repository-owned migration behavior that previously could pass by echoing response fields without verifying database effects.
- Keep cleanup verification in Cucumber support setup instead of modeling it as an application scenario.
- Validation gap: full feature runs currently fail on the external github source examples returning 500, while local Postgres scenarios pass before those failures.
- Validation gap: benchmarks currently fail on the HTTP scenario memory assertion with Errno::ESRCH after the HTTP migration returns 200.

## Testing

- `make -C test lint` - passed
- `make features` - failed: github source examples returned 500
- `make benchmarks` - failed: HTTP memory check lost the server process after a 200 response

AI-assisted-by: [Codex](https://openai.com/codex/)
