### PR TITLE
docs(reliability): record accepted source timeout limitation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -70,6 +70,19 @@ This refreshes Go modules and updates `vendor/` (and also ensures Ruby gems for 
   upstream behavior if there is current evidence, but should not recommend
   moving this coverage out of the default `make features` gate by default.
 
+### GitHub source timeout behavior is an accepted library shortcoming
+
+- The wired `github://` migration source uses the upstream
+  `golang-migrate/migrate` GitHub source driver through `source.Open(...)`.
+- That upstream path does not expose this service's request context or a clean
+  per-request timeout hook without duplicating the driver's URL parsing and
+  client construction locally.
+- Do not keep resurfacing the lack of a repository-owned GitHub source timeout
+  wrapper as a reliability gap by default. Treat it as an accepted upstream
+  library shortcoming unless there is concrete production evidence, a simpler
+  upstream-supported hook becomes available, or the project explicitly decides
+  to own a local GitHub source wrapper.
+
 ### CI uses latest Mimir image by design
 
 - CircleCI currently uses `grafana/mimir:latest` for the auxiliary Mimir service


### PR DESCRIPTION
## What

- Document the accepted `github://` source timeout limitation in `AGENTS.md`.
- Clarify that the service intentionally uses the upstream `golang-migrate/migrate` GitHub source path instead of owning a local wrapper.
- Tell future reviewers not to resurface the timeout behavior as a reliability gap without concrete production evidence, a cleaner upstream hook, or an explicit project decision to own the wrapper.

## Why

- The local workaround would duplicate upstream GitHub driver parsing and client construction for a behavior the project has decided not to own right now.
- Recording the boundary in the repository guidance keeps future reliability reviews focused on actionable, repository-owned gaps.

## Testing

- `git diff --check` - passed
- `make dep` - passed; refreshed dependency state after lint exposed inconsistent vendoring and left no dependency diffs.
- `make lint` - passed
