### PR TITLE
feat(deps): upgraded github.com/alexfalkowski/go-service/v2 to v2.576.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.26.0
 
 require (
 	github.com/alexfalkowski/go-health/v2 v2.28.0
-	github.com/alexfalkowski/go-service/v2 v2.575.0
+	github.com/alexfalkowski/go-service/v2 v2.576.0
 	github.com/golang-migrate/migrate/v4 v4.19.1
 	github.com/jackc/pgx/v5 v5.10.0
 	go.opentelemetry.io/otel/metric v1.44.0

--- a/go.sum
+++ b/go.sum
@@ -23,8 +23,8 @@ github.com/aead/cmac v0.0.0-20160719120800-7af84192f0b1 h1:+JkXLHME8vLJafGhOH4ao
 github.com/aead/cmac v0.0.0-20160719120800-7af84192f0b1/go.mod h1:nuudZmJhzWtx2212z+pkuy7B6nkBqa+xwNXZHL1j8cg=
 github.com/alexfalkowski/go-health/v2 v2.28.0 h1:m8joTG7hrUfPZCzlaW8y6ZkDaxro95frteIvydXjfWE=
 github.com/alexfalkowski/go-health/v2 v2.28.0/go.mod h1:oIzLvkIhiXUbPSYQRW2Gezah+sW+ZEY9BcoOi/5Agxo=
-github.com/alexfalkowski/go-service/v2 v2.575.0 h1:jf8au7Ek4vNvbstfZ3JEx+9A3SbPhzEBByug5ziVTsg=
-github.com/alexfalkowski/go-service/v2 v2.575.0/go.mod h1:R2x9+E4OLeGvjmNldbSp+84K7l8hbe+dnF80cOsae50=
+github.com/alexfalkowski/go-service/v2 v2.576.0 h1:/gCBr+iM0HSu09iP/KtOPupEwotMq2xjm2hQoeGGltw=
+github.com/alexfalkowski/go-service/v2 v2.576.0/go.mod h1:R2x9+E4OLeGvjmNldbSp+84K7l8hbe+dnF80cOsae50=
 github.com/alexfalkowski/go-sync v1.24.0 h1:CrV+LITc8C78v01u9ATGvIgipmNtJlZWGWW1znFsdjM=
 github.com/alexfalkowski/go-sync v1.24.0/go.mod h1:2vmRtpHHSoGPIiXJ7j3lm0GK2SI32XbYvvrjrZ+eo/k=
 github.com/arl/statsviz v0.8.0 h1:O6GjjVxEDxcByAucOSl29HaGYLXsuwA3ujJw8H9E7/U=


### PR DESCRIPTION
https://github.com/alexfalkowski/go-service/releases/tag/v2.576.0
