### PR TITLE
docs(readme): clarify migration contracts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -181,7 +181,7 @@ Run `make help` for the full list (help is generated from Makefile comments).
 Example run using the repo’s dev/test config:
 
 ```sh
-./migrieren server -i file:test/.config/server.yml
+./migrieren server -config file:test/.config/server.yml
 ```
 
 There is also a dev helper:
@@ -190,7 +190,7 @@ There is also a dev helper:
 make dev
 ```
 
-(Observed: `dev` uses `air` and runs `make dep build` before launching `./migrieren server -i file:test/.config/server.yml`.)
+(Observed: `dev` uses `air` and runs `make dep build` before launching `./migrieren server -config file:test/.config/server.yml`.)
 
 ### Test
 
@@ -275,6 +275,7 @@ From repo root:
 ```sh
 make proto-generate
 make proto-breaking
+make proto-stale
 make proto-lint
 make proto-format
 ```
@@ -299,6 +300,7 @@ CircleCI (`.circleci/config.yml`) does roughly:
 - `make dep`
 - `make lint`
 - `make proto-breaking`
+- `make proto-stale`
 - `make sec`
 - `make trivy-repo`
 - `make features`
@@ -368,7 +370,7 @@ Uses `github.com/alexfalkowski/go-service/v2/di` with Fx-style modules:
 ### Error handling
 
 - Domain errors are exported vars in packages and returned upward (e.g. migrate errors in `internal/migrate/migrate.go`).
-- gRPC transport maps a “not found” error to `codes.NotFound` and everything else to `codes.Internal` (`internal/api/v1/transport/grpc/grpc.go`).
+- gRPC transport maps “not found” to `codes.NotFound`, cancellation to `codes.Canceled`, deadlines to `codes.DeadlineExceeded`, and other migration failures to `codes.Internal` (`internal/api/v1/transport/grpc/grpc.go`).
 - Migration errors are attached to request metadata via `meta.WithAttribute(...)`.
 
 ### Formatting / lint

--- a/README.md
+++ b/README.md
@@ -191,7 +191,7 @@ Response:
 - `meta`: request metadata emitted by the service runtime.
 - `migration.database`: echoed database name.
 - `migration.version`: echoed target version.
-- `migration.logs`: in-memory migration log lines collected during execution.
+- `migration.logs`: in-memory migration log lines collected during execution. Returned logs are capped at 100 entries and start with `migration logs truncated` when older lines were discarded.
 
 Conceptual request:
 
@@ -231,6 +231,10 @@ Transport behavior is intentionally simple:
 - Configuration, source, database, or migration failures:
   - gRPC: `Internal`
   - HTTP: `500`
+- Request canceled by the caller:
+  - gRPC: `Canceled`
+- Request deadline exceeded:
+  - gRPC: `DeadlineExceeded`
 
 The core migrator also treats `migrate.ErrNoChange` as a successful no-op and still returns any accumulated logs.
 
@@ -278,6 +282,7 @@ make coverage
 make proto-generate
 make proto-lint
 make proto-breaking
+make proto-stale
 ```
 
 What those do in this repository:
@@ -332,7 +337,11 @@ Lint and breaking-change checks:
 ```sh
 make proto-lint
 make proto-breaking
+make proto-stale
 ```
+
+`make proto-stale` verifies generated protobuf outputs are current; CI runs it
+after the breaking-change check.
 
 Generation is configured in `api/buf.gen.yaml` and currently writes:
 

--- a/api/migrieren/v1/service.pb.go
+++ b/api/migrieren/v1/service.pb.go
@@ -21,12 +21,17 @@ const (
 	_ = protoimpl.EnforceVersion(protoimpl.MaxVersion - 20)
 )
 
-// Migration for a specific database and version with logs.
+// Migration reports the target database, version, and bounded migrate logs.
 type Migration struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	Database      string                 `protobuf:"bytes,1,opt,name=database,proto3" json:"database,omitempty"`
-	Version       uint64                 `protobuf:"varint,2,opt,name=version,proto3" json:"version,omitempty"`
-	Logs          []string               `protobuf:"bytes,3,rep,name=logs,proto3" json:"logs,omitempty"`
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// database is the configured logical database name requested by the caller.
+	Database string `protobuf:"bytes,1,opt,name=database,proto3" json:"database,omitempty"`
+	// version is the target migration version echoed from the request.
+	Version uint64 `protobuf:"varint,2,opt,name=version,proto3" json:"version,omitempty"`
+	// logs contains in-memory migrate log lines collected during execution.
+	// The service caps this list at 100 entries and marks truncation with
+	// "migration logs truncated" as the first entry.
+	Logs          []string `protobuf:"bytes,3,rep,name=logs,proto3" json:"logs,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -82,11 +87,13 @@ func (x *Migration) GetLogs() []string {
 	return nil
 }
 
-// MigrateRequest for a specific database and version.
+// MigrateRequest identifies a configured database and target schema version.
 type MigrateRequest struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	Database      string                 `protobuf:"bytes,1,opt,name=database,proto3" json:"database,omitempty"`
-	Version       uint64                 `protobuf:"varint,2,opt,name=version,proto3" json:"version,omitempty"`
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// database is the configured logical database name, not a raw database URL.
+	Database string `protobuf:"bytes,1,opt,name=database,proto3" json:"database,omitempty"`
+	// version is the target migration version. It must be greater than zero.
+	Version       uint64 `protobuf:"varint,2,opt,name=version,proto3" json:"version,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -135,11 +142,13 @@ func (x *MigrateRequest) GetVersion() uint64 {
 	return 0
 }
 
-// MigrateResponse for a specific database and version.
+// MigrateResponse contains response metadata and the migration result.
 type MigrateResponse struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	Meta          map[string]string      `protobuf:"bytes,1,rep,name=meta,proto3" json:"meta,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
-	Migration     *Migration             `protobuf:"bytes,2,opt,name=migration,proto3" json:"migration,omitempty"`
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// meta contains request metadata emitted by the service runtime.
+	Meta map[string]string `protobuf:"bytes,1,rep,name=meta,proto3" json:"meta,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+	// migration echoes the requested database/version and collected logs.
+	Migration     *Migration `protobuf:"bytes,2,opt,name=migration,proto3" json:"migration,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }

--- a/api/migrieren/v1/service.proto
+++ b/api/migrieren/v1/service.proto
@@ -5,27 +5,45 @@ package migrieren.v1;
 option go_package = "github.com/alexfalkowski/migrieren/api/migrieren/v1";
 option ruby_package = "Migrieren::V1";
 
-// Migration for a specific database and version with logs.
+// Migration reports the target database, version, and bounded migrate logs.
 message Migration {
+  // database is the configured logical database name requested by the caller.
   string database = 1;
+
+  // version is the target migration version echoed from the request.
   uint64 version = 2;
+
+  // logs contains in-memory migrate log lines collected during execution.
+  // The service caps this list at 100 entries and marks truncation with
+  // "migration logs truncated" as the first entry.
   repeated string logs = 3;
 }
 
-// MigrateRequest for a specific database and version.
+// MigrateRequest identifies a configured database and target schema version.
 message MigrateRequest {
+  // database is the configured logical database name, not a raw database URL.
   string database = 1;
+
+  // version is the target migration version. It must be greater than zero.
   uint64 version = 2;
 }
 
-// MigrateResponse for a specific database and version.
+// MigrateResponse contains response metadata and the migration result.
 message MigrateResponse {
+  // meta contains request metadata emitted by the service runtime.
   map<string, string> meta = 1;
+
+  // migration echoes the requested database/version and collected logs.
   Migration migration = 2;
 }
 
-// Service allows to migrate databases.
+// Service runs configured database migrations.
 service Service {
-  // Migrate a specific database to version.
+  // Migrate migrates a configured database to the requested version.
+  //
+  // Errors use InvalidArgument for zero versions, NotFound for unknown
+  // databases, Canceled/DeadlineExceeded for stopped requests, and Internal for
+  // configuration, source, database, or migration failures. Failure diagnostics
+  // are returned in response metadata/trailers when available.
   rpc Migrate(MigrateRequest) returns (MigrateResponse) {}
 }

--- a/api/migrieren/v1/service_grpc.pb.go
+++ b/api/migrieren/v1/service_grpc.pb.go
@@ -26,9 +26,14 @@ const (
 //
 // For semantics around ctx use and closing/ending streaming RPCs, please refer to https://pkg.go.dev/google.golang.org/grpc/?tab=doc#ClientConn.NewStream.
 //
-// Service allows to migrate databases.
+// Service runs configured database migrations.
 type ServiceClient interface {
-	// Migrate a specific database to version.
+	// Migrate migrates a configured database to the requested version.
+	//
+	// Errors use InvalidArgument for zero versions, NotFound for unknown
+	// databases, Canceled/DeadlineExceeded for stopped requests, and Internal for
+	// configuration, source, database, or migration failures. Failure diagnostics
+	// are returned in response metadata/trailers when available.
 	Migrate(ctx context.Context, in *MigrateRequest, opts ...grpc.CallOption) (*MigrateResponse, error)
 }
 
@@ -54,9 +59,14 @@ func (c *serviceClient) Migrate(ctx context.Context, in *MigrateRequest, opts ..
 // All implementations must embed UnimplementedServiceServer
 // for forward compatibility.
 //
-// Service allows to migrate databases.
+// Service runs configured database migrations.
 type ServiceServer interface {
-	// Migrate a specific database to version.
+	// Migrate migrates a configured database to the requested version.
+	//
+	// Errors use InvalidArgument for zero versions, NotFound for unknown
+	// databases, Canceled/DeadlineExceeded for stopped requests, and Internal for
+	// configuration, source, database, or migration failures. Failure diagnostics
+	// are returned in response metadata/trailers when available.
 	Migrate(context.Context, *MigrateRequest) (*MigrateResponse, error)
 	mustEmbedUnimplementedServiceServer()
 }

--- a/internal/health/checker/checker.go
+++ b/internal/health/checker/checker.go
@@ -18,7 +18,8 @@ func NewNoopChecker() *checker.NoopChecker {
 // NewMigrator constructs a health checker for one configured migration target.
 //
 // The checker resolves the migration source and database URL through fs, then
-// validates both within the provided timeout.
+// validates the source reference and database connectivity within the provided
+// timeout.
 func NewMigrator(db *migrate.Database, fs *os.FS, migrator *migrate.Migrator, timeout time.Duration) *Migrator {
 	return &Migrator{db: db, fs: fs, migrator: migrator, timeout: timeout}
 }
@@ -33,7 +34,9 @@ type Migrator struct {
 }
 
 // Check resolves the migration source and database URL, then validates the
-// source and pings the target database within the configured timeout.
+// source reference and pings the target database within the configured timeout.
+// GitHub source checks are syntax-only; the remote source is opened during
+// migration execution.
 func (c *Migrator) Check(ctx context.Context) error {
 	src, err := c.db.GetSource(c.fs)
 	if err != nil {

--- a/internal/health/config.go
+++ b/internal/health/config.go
@@ -8,7 +8,8 @@ import "github.com/alexfalkowski/go-service/v2/time"
 // parsed as Go durations.
 //
 // Duration controls how often health registrations are evaluated/updated.
-// Timeout is reserved for probe/check timeout configuration.
+// Timeout caps online checks and each per-database source/database health
+// check.
 type Config struct {
 	Duration time.Duration `yaml:"duration,omitempty" json:"duration,omitempty" toml:"duration,omitempty" validate:"gt=0"`
 	Timeout  time.Duration `yaml:"timeout,omitempty" json:"timeout,omitempty" toml:"timeout,omitempty" validate:"gt=0"`

--- a/internal/migrate/database/database.go
+++ b/internal/migrate/database/database.go
@@ -27,8 +27,9 @@ var telemetryAttrs = telemetry.WithAttributes(attributes.DBSystemNamePostgreSQL)
 // the remaining request duration. A shorter configured statement timeout is
 // preserved.
 //
-// URL handling errors are returned to the caller via the exported sentinel
-// errors in this package.
+// Empty, malformed, and unsupported-scheme URLs are returned to the caller via
+// the exported sentinel errors in this package. Driver-specific option parsing
+// errors, such as invalid pgx query parameters, are returned as-is.
 //
 // Telemetry wiring is treated differently on purpose: failures from
 // telemetry.Open or telemetry.RegisterDBStatsMetrics are considered

--- a/internal/migrate/doc.go
+++ b/internal/migrate/doc.go
@@ -1,17 +1,15 @@
 // Package migrate provides the core migration engine used by the service.
 //
 // This package wraps github.com/golang-migrate/migrate/v4 to perform database
-// schema migrations and to "ping" databases to verify connectivity and basic
-// migrator health.
+// schema migrations and to "ping" databases to verify connectivity.
 //
 // # Overview
 //
 // The primary type is [Migrator], which offers:
 //
-//   - [Migrator.Migrate] to migrate a database to a target version, returning
-//     in-memory migration logs.
-//   - [Migrator.Ping] to validate that the migration source and database can be
-//     opened and that the database is reachable.
+//   - [Migrator.Migrate] to open a migration source and database, migrate the
+//     database to a target version, and return in-memory migration logs.
+//   - [Migrator.Ping] to validate that the database can be opened and reached.
 //
 // The migrator operates on two string inputs:
 //
@@ -41,13 +39,18 @@
 // # Logs
 //
 // Migration logs are captured in memory and returned from [Migrator.Migrate] as
-// a slice of strings. When the underlying migrate engine reports
-// migrate.ErrNoChange, it is treated as a successful no-op and the accumulated
-// logs are still returned.
+// a slice of strings. The logger keeps at most 100 entries; when output exceeds
+// that cap, the first returned entry is "migration logs truncated" and the
+// remaining entries are the latest log lines. When the underlying migrate
+// engine reports migrate.ErrNoChange, it is treated as a successful no-op and
+// the accumulated logs are still returned.
 //
 // # Resource management
 //
 // The underlying migrate engine allocates resources for both the migration
-// source and the database connection. This package closes those resources after
-// each operation before returning to the caller.
+// source and the database connection. Normal completion closes those resources
+// before returning to the caller. When the request context is canceled or its
+// deadline expires while a migration is running, this package requests a
+// graceful stop and closes resources asynchronously so cancellation can return
+// promptly.
 package migrate

--- a/internal/migrate/migrate.go
+++ b/internal/migrate/migrate.go
@@ -32,8 +32,9 @@ var (
 // NewMigrator creates a new [Migrator] instance.
 //
 // The returned migrator is stateless; each call to [Migrator.Migrate] or
-// [Migrator.Ping] creates a new underlying github.com/golang-migrate/migrate/v4
-// engine instance and ensures resources are closed before returning.
+// [Migrator.Ping] creates fresh underlying resources. Migration resources are
+// closed before returning on normal completion and closed asynchronously when an
+// in-flight migration is stopped by context cancellation or deadline expiry.
 func NewMigrator() *Migrator {
 	return &Migrator{}
 }
@@ -60,7 +61,8 @@ type Migrator struct{}
 //     source/database setup or migration execution fails.
 //   - logs: in-memory migration logs captured during the operation. Logs may be
 //     returned on successful migrations, no-op migrations, and migration
-//     execution failures.
+//     execution failures. At most 100 entries are returned; truncation is marked
+//     by "migration logs truncated" as the first entry.
 //   - error: nil on success; otherwise one of:
 //     [ErrInvalidConfig] (cannot open src/db),
 //     [ErrInvalidMigration] (migration failed),
@@ -100,7 +102,8 @@ func (m *Migrator) Migrate(ctx context.Context, src, db string, version uint64) 
 //
 // Ping does not apply any migrations. It pings the database with ctx instead
 // of using golang-migrate's Version path, because the pgx migrate driver does
-// not accept a request context for Version.
+// not accept a request context for Version. Ping does not inspect or open a
+// migration source.
 //
 // Returns the input context, or a derived context containing "pingError" when
 // database configuration or connectivity inspection fails, plus nil on success

--- a/internal/migrate/source/source.go
+++ b/internal/migrate/source/source.go
@@ -10,6 +10,10 @@ import (
 
 // Check validates that sourceURL can be used as a migration source without
 // making unbounded external dependency calls.
+//
+// GitHub sources are parsed but not opened here, because the upstream source
+// driver does not expose a request-scoped timeout hook. The actual GitHub source
+// is opened later during migration execution.
 func Check(ctx context.Context, sourceURL string) error {
 	if err := ctx.Err(); err != nil {
 		return err

--- a/internal/migrate/telemetry/logger/logger.go
+++ b/internal/migrate/telemetry/logger/logger.go
@@ -26,6 +26,10 @@ type Logger struct {
 }
 
 // Printf formats and stores a log line.
+//
+// The logger keeps at most 100 entries. When that limit is exceeded, the first
+// entry is replaced with "migration logs truncated" and the remaining entries
+// are the latest log lines.
 func (l *Logger) Printf(format string, v ...any) {
 	l.mu.Lock()
 	defer l.mu.Unlock()
@@ -37,6 +41,9 @@ func (l *Logger) Printf(format string, v ...any) {
 }
 
 // Logs returns the captured log lines in insertion order.
+//
+// A first entry of "migration logs truncated" means earlier log lines were
+// discarded to keep only the latest 100 entries.
 func (l *Logger) Logs() []string {
 	l.mu.RLock()
 	defer l.mu.RUnlock()

--- a/test/lib/migrieren.rb
+++ b/test/lib/migrieren.rb
@@ -26,10 +26,10 @@ require 'migrieren/v1/service_services_pb'
 # - centralize shared configuration such as gRPC user-agent headers.
 #
 # @example Using the HTTP façade client
-#   Migrieren::V1.server_http.migrate('test', 1)
+#   Migrieren::V1.server_http.migrate('postgres', 1)
 #
 # @example Using the gRPC API stub
-#   req = Migrieren::V1::MigrateRequest.new(database: 'test', version: 1)
+#   req = Migrieren::V1::MigrateRequest.new(database: 'postgres', version: 1)
 #   Migrieren::V1.server_grpc.migrate(req)
 #
 module Migrieren

--- a/test/lib/migrieren/v1/service_services_pb.rb
+++ b/test/lib/migrieren/v1/service_services_pb.rb
@@ -7,7 +7,7 @@ require 'migrieren/v1/service_pb'
 module Migrieren
   module V1
     module Service
-      # Service allows to migrate databases.
+      # Service runs configured database migrations.
       class Service
 
         include ::GRPC::GenericService
@@ -16,7 +16,12 @@ module Migrieren
         self.unmarshal_class_method = :decode
         self.service_name = 'migrieren.v1.Service'
 
-        # Migrate a specific database to version.
+        # Migrate migrates a configured database to the requested version.
+        #
+        # Errors use InvalidArgument for zero versions, NotFound for unknown
+        # databases, Canceled/DeadlineExceeded for stopped requests, and Internal for
+        # configuration, source, database, or migration failures. Failure diagnostics
+        # are returned in response metadata/trailers when available.
         rpc :Migrate, ::Migrieren::V1::MigrateRequest, ::Migrieren::V1::MigrateResponse
       end
 


### PR DESCRIPTION
## What

- Expanded the protobuf migration contract comments and regenerated the Go/Ruby stubs so generated API docs describe logical database names, positive versions, bounded logs, failure metadata, and status behavior.
- Corrected Go package/API comments for source checking, health timeouts, migration log truncation, cancellation cleanup, and database URL error behavior.
- Updated README, AGENTS, and Ruby harness examples to match the supported config flag, proto stale check, cancellation/deadline mappings, and configured Postgres target.

## Why

- Keeps public API, operator, and maintainer documentation aligned with the service behavior that callers depend on for migration requests, health interpretation, retries, and debugging.
- Reduces local workflow confusion by documenting the actual server config flag, CI protobuf freshness check, and copy-pasteable harness examples.

## Testing

- `make proto-lint` - passed
- `make proto-generate` - passed
- `make proto-stale` - passed
- `make -C test lint` - passed
- `make lint` - passed
- `make features` - passed, covering 45 scenarios and 99 steps
