### PR TITLE
docs(readme): clarify migration diagnostics and configuration contracts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,14 +40,14 @@ This refreshes Go modules and updates `vendor/` (and also ensures Ruby gems for 
     - any environment assumptions (localhost ports, DB URI).
   - Do not edit generated protobuf/grpc Ruby stubs; update `.proto` comments instead, then re-generate.
 
-### Telemetry fail-fast behavior is intentional
+### Database telemetry setup errors are returned by design
 
 - In `internal/migrate/database/database.go`, failures from `telemetry.Open(...)`
-  and `telemetry.RegisterDBStatsMetrics(...)` are intentionally treated as
-  startup/runtime invariants and use `runtime.Must(...)` by design.
-- Reviewers should not flag those specific panic paths as accidental error
-  handling; the intended behavior is to fail fast if database telemetry cannot
-  be initialized.
+  and `telemetry.RegisterDBStatsMetrics(...)` are intentionally returned through
+  the migration or ping path.
+- Reviewers should not suggest converting those setup failures to
+  `runtime.Must(...)` fail-fast paths without a concrete service startup
+  invariant that requires changing the current runtime behavior.
 
 ### Top-level runtime config sections are required
 

--- a/README.md
+++ b/README.md
@@ -128,7 +128,8 @@ transport:
 
 ### 🗄️ Migration database entries
 
-Each configured database entry has:
+`migrate.databases` must contain at least one entry. Each entry must have a
+unique `name` and all of these fields:
 
 - `name`: the logical database name used by the API request.
 - `source`: how to resolve the migration source URL.
@@ -159,11 +160,31 @@ migrate:
 
 ultimately migrates Postgres using the `file://migrations` source and the `pgx5://...` database URL resolved from those files.
 
+### 🐘 Postgres URL options
+
+Postgres targets use `pgx5://...` URLs. In addition to normal Postgres
+connection parameters, Migrieren recognizes these migration-driver query
+parameters:
+
+- `x-migrations-table`: migration table name. When omitted, the upstream driver
+  default is used.
+- `x-migrations-table-quoted`: boolean. When `true`, `x-migrations-table` must
+  include surrounding double quotes.
+- `x-statement-timeout`: statement timeout in milliseconds. Request deadlines
+  can lower this timeout for an individual migration or health check.
+- `x-multi-statement`: boolean enabling multi-statement migrations.
+- `x-multi-statement-max-size`: byte limit for multi-statement migrations.
+  Empty or non-positive values use the upstream driver default.
+
+Malformed boolean or integer values reject the configured database URL.
+
 ### 🧪 About the checked-in test config
 
 `test/.config/server.yml` intentionally contains both valid and invalid database definitions:
 
 - `postgres` and `github` are used for successful migration scenarios.
+- `timeout` is used for deadline and cancellation scenarios.
+- `logs` is used for bounded migration log scenarios.
 - `missing_source`, `invalid_source`, `missing_url`, `invalid_url`, `invalid_db`, and `invalid_port` exist to exercise failure paths in feature tests.
 
 > [!IMPORTANT]
@@ -237,6 +258,15 @@ Transport behavior is intentionally simple:
   - gRPC: `DeadlineExceeded`
 
 The core migrator also treats `migrate.ErrNoChange` as a successful no-op and still returns any accumulated logs.
+
+For gRPC requests that reach migration execution and then fail, the server also
+adds failure diagnostics as trailers:
+
+- `migration-error`: one of `not_found`, `canceled`, `deadline_exceeded`,
+  `invalid_config`, `invalid_migration`, or `unknown`.
+- `migration-log-count`: number of migration log lines returned.
+- `migration-stage`: `source` or `url` when configuration resolution failed.
+- `migration-log-last`: last migration log line when logs were captured.
 
 ## 💓 Health and observability
 

--- a/api/migrieren/v1/doc.go
+++ b/api/migrieren/v1/doc.go
@@ -1,0 +1,7 @@
+// Package v1 contains the generated protobuf and gRPC bindings for the
+// migrieren.v1 API.
+//
+// The service contract is owned by service.proto in this directory. Update the
+// proto comments and regenerate the stubs with the repository protobuf targets
+// instead of editing generated Go or Ruby files by hand.
+package v1

--- a/api/migrieren/v1/service.proto
+++ b/api/migrieren/v1/service.proto
@@ -43,7 +43,14 @@ service Service {
   //
   // Errors use InvalidArgument for zero versions, NotFound for unknown
   // databases, Canceled/DeadlineExceeded for stopped requests, and Internal for
-  // configuration, source, database, or migration failures. Failure diagnostics
-  // are returned in response metadata/trailers when available.
+  // configuration, source, database, or migration failures.
+  //
+  // gRPC failures from migration execution include trailers when the request
+  // reaches the migrator:
+  // - migration-error: not_found, canceled, deadline_exceeded, invalid_config,
+  //   invalid_migration, or unknown.
+  // - migration-log-count: the number of migration log lines returned.
+  // - migration-stage: source or url when configuration resolution failed.
+  // - migration-log-last: the last migration log line when logs were captured.
   rpc Migrate(MigrateRequest) returns (MigrateResponse) {}
 }

--- a/api/migrieren/v1/service_grpc.pb.go
+++ b/api/migrieren/v1/service_grpc.pb.go
@@ -32,8 +32,15 @@ type ServiceClient interface {
 	//
 	// Errors use InvalidArgument for zero versions, NotFound for unknown
 	// databases, Canceled/DeadlineExceeded for stopped requests, and Internal for
-	// configuration, source, database, or migration failures. Failure diagnostics
-	// are returned in response metadata/trailers when available.
+	// configuration, source, database, or migration failures.
+	//
+	// gRPC failures from migration execution include trailers when the request
+	// reaches the migrator:
+	//   - migration-error: not_found, canceled, deadline_exceeded, invalid_config,
+	//     invalid_migration, or unknown.
+	//   - migration-log-count: the number of migration log lines returned.
+	//   - migration-stage: source or url when configuration resolution failed.
+	//   - migration-log-last: the last migration log line when logs were captured.
 	Migrate(ctx context.Context, in *MigrateRequest, opts ...grpc.CallOption) (*MigrateResponse, error)
 }
 
@@ -65,8 +72,15 @@ type ServiceServer interface {
 	//
 	// Errors use InvalidArgument for zero versions, NotFound for unknown
 	// databases, Canceled/DeadlineExceeded for stopped requests, and Internal for
-	// configuration, source, database, or migration failures. Failure diagnostics
-	// are returned in response metadata/trailers when available.
+	// configuration, source, database, or migration failures.
+	//
+	// gRPC failures from migration execution include trailers when the request
+	// reaches the migrator:
+	//   - migration-error: not_found, canceled, deadline_exceeded, invalid_config,
+	//     invalid_migration, or unknown.
+	//   - migration-log-count: the number of migration log lines returned.
+	//   - migration-stage: source or url when configuration resolution failed.
+	//   - migration-log-last: the last migration log line when logs were captured.
 	Migrate(context.Context, *MigrateRequest) (*MigrateResponse, error)
 	mustEmbedUnimplementedServiceServer()
 }

--- a/internal/migrate/config.go
+++ b/internal/migrate/config.go
@@ -10,6 +10,10 @@ import (
 var ErrNotFound = errors.New("not found")
 
 // Config defines the configured migration targets for the service.
+//
+// Databases must be non-empty and each entry must have a unique Name. The
+// service validates that every configured entry is present before startup
+// completes.
 type Config struct {
 	Databases []*Database `yaml:"databases" json:"databases" toml:"databases" validate:"gt=0,unique=Name,dive,required"`
 }
@@ -30,6 +34,8 @@ func (c *Config) Database(name string) (*Database, error) {
 //
 // Source and URL are resolved through the service filesystem abstraction so they
 // can point at literal values or external sources such as `file:...`.
+//
+// Name, Source, and URL are all required configuration fields.
 type Database struct {
 	Name   string `yaml:"name,omitempty" json:"name,omitempty" toml:"name,omitempty" validate:"required"`
 	Source string `yaml:"source,omitempty" json:"source,omitempty" toml:"source,omitempty" validate:"required"`

--- a/internal/migrate/database/database.go
+++ b/internal/migrate/database/database.go
@@ -31,11 +31,10 @@ var telemetryAttrs = telemetry.WithAttributes(attributes.DBSystemNamePostgreSQL)
 // the exported sentinel errors in this package. Driver-specific option parsing
 // errors, such as invalid pgx query parameters, are returned as-is.
 //
-// Telemetry wiring is treated differently on purpose: failures from
-// telemetry.Open or telemetry.RegisterDBStatsMetrics are considered
-// process-level misconfiguration/invariant violations for this service, so this
-// function fails fast via runtime.Must rather than degrading to a runtime
-// migration error.
+// Telemetry setup errors from telemetry.Open or
+// telemetry.RegisterDBStatsMetrics are returned to the caller. Migration paths
+// map those setup failures through the core migrator's invalid-config error,
+// while health/ping paths return the underlying setup or connectivity error.
 func Open(ctx context.Context, databaseURL string) (database.Driver, error) {
 	u, err := url.Parse(databaseURL)
 	if err != nil {

--- a/internal/migrate/pgx/pgx.go
+++ b/internal/migrate/pgx/pgx.go
@@ -19,6 +19,20 @@ var ErrInvalidMigrationsTable = errors.New("migrate pgx: invalid migrations tabl
 type Config = pgx.Config
 
 // ParseConfig extracts golang-migrate pgx driver options from u.
+//
+// Supported pgx5 query parameters:
+//   - x-migrations-table: migration table name. When omitted, the upstream
+//     driver default is used.
+//   - x-migrations-table-quoted: boolean parsed with strconv.ParseBool. When
+//     true, x-migrations-table must include surrounding double quotes.
+//   - x-statement-timeout: integer statement timeout in milliseconds. Malformed
+//     integers reject the URL.
+//   - x-multi-statement: boolean parsed with strconv.ParseBool.
+//   - x-multi-statement-max-size: integer byte limit for multi-statement
+//     migrations. Empty or non-positive values use the upstream driver default.
+//
+// Malformed booleans or integers return parsing errors. An invalid quoted table
+// configuration returns [ErrInvalidMigrationsTable].
 func ParseConfig(u *url.URL) (*Config, error) {
 	query := u.Query()
 	migrationsTable, migrationsTableQuoted, err := parseMigrationsTableOptions(query)

--- a/test/lib/migrieren.rb
+++ b/test/lib/migrieren.rb
@@ -37,9 +37,9 @@ module Migrieren
     ##
     # Returns the observability client used by tests.
     #
-    # This client is provided by the `nonnative` test utilities and is used by
-    # observability-related steps to query or assert on telemetry emitted by the
-    # service.
+    # This client is provided by the `nonnative` test utilities and is available
+    # to feature-harness code that needs to query or assert on telemetry emitted
+    # by the service.
     #
     # The client points at the service's HTTP endpoint.
     #
@@ -99,7 +99,11 @@ module Migrieren
     # timeout in `.config/server.yml`, so ordinary requests can finish while a
     # stalled endpoint still fails before an outer Cucumber or CI timeout.
     #
-    # @param metadata [Hash] additional request metadata
+    # Each call includes a generated `request-id` metadata value. Caller-provided
+    # metadata is merged afterward, so scenarios can override that value when
+    # they need a specific request identifier.
+    #
+    # @param metadata [Hash] request metadata merged after the generated default
     # @param deadline [Time, nil] optional deadline override for scenarios that
     #   intentionally exercise request cancellation
     # @return [Hash] options compatible with Ruby gRPC unary calls

--- a/test/lib/migrieren/v1/service_services_pb.rb
+++ b/test/lib/migrieren/v1/service_services_pb.rb
@@ -20,8 +20,15 @@ module Migrieren
         #
         # Errors use InvalidArgument for zero versions, NotFound for unknown
         # databases, Canceled/DeadlineExceeded for stopped requests, and Internal for
-        # configuration, source, database, or migration failures. Failure diagnostics
-        # are returned in response metadata/trailers when available.
+        # configuration, source, database, or migration failures.
+        #
+        # gRPC failures from migration execution include trailers when the request
+        # reaches the migrator:
+        # - migration-error: not_found, canceled, deadline_exceeded, invalid_config,
+        #   invalid_migration, or unknown.
+        # - migration-log-count: the number of migration log lines returned.
+        # - migration-stage: source or url when configuration resolution failed.
+        # - migration-log-last: the last migration log line when logs were captured.
         rpc :Migrate, ::Migrieren::V1::MigrateRequest, ::Migrieren::V1::MigrateResponse
       end
 


### PR DESCRIPTION
## What

- Clarifies the migration configuration contract, including non-empty unique database entries and supported pgx5 URL query parameters.
- Documents gRPC migration failure trailers and regenerates the protobuf service stubs from the updated proto comments.
- Adds a source-owned package overview for the generated v1 API package and corrects stale Go/Ruby documentation around telemetry setup and feature-harness helpers.

## Why

- Reduces maintainer and operator confusion around configuration, diagnostic metadata, and generated API ownership without changing runtime behavior.
- Keeps reviewer guidance aligned with the current database telemetry error path and makes intentional feature-test fixtures easier to preserve.

## Testing

- `git diff --check` - passed
- `make proto-lint` - passed
- `make lint` - passed
- `make proto-generate` - passed; rerunning it made no additional changes
- `make proto-stale` - not run locally because the target reports any working-tree diff on an uncommitted change; CI runs it from a clean checkout after generation

AI-assisted-by: [Codex](https://openai.com/codex/)
