### PR TITLE
docs(readme): clarify migration service contracts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -138,7 +138,7 @@ Note: `.gitmodules` points `bin` at `git@github.com:alexfalkowski/bin.git` (SSH 
 
 ## 1) Project type
 
-- **Primary**: Go service (`go.mod` module `github.com/alexfalkowski/migrieren`, `go 1.26.0`).
+- **Primary**: Go service (`go.mod` module `github.com/alexfalkowski/migrieren`; use the Go version declared there).
 - **API**: Protobuf/gRPC in `api/`, managed by `buf`.
 - **Integration/feature tests**: Ruby + Cucumber in `test/`.
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Database URLs use the `pgx5://` scheme in config and secrets. Internally the ser
 
 ## ✅ Prerequisites
 
-- Go `1.26.0` or newer.
+- Go, using the version declared in `go.mod`.
 - Ruby and Bundler for the feature-test harness under `test/`.
 - The `bin/` git submodule. Most `make` targets delegate into scripts under that submodule.
 
@@ -68,6 +68,9 @@ This builds `./migrieren` in the repository root.
 
 > [!WARNING]
 > The checked-in test config points Postgres at `localhost:5433` and OTLP tracing at `http://localhost:4318/v1/traces`. Start the local feature-test services or provide your own config before expecting migrations, health checks, and tracing to succeed.
+> In the feature harness, `localhost:5433` is a nonnative fault-injection proxy
+> to a backing Postgres instance on `localhost:5432`; both ports must line up
+> with either the local harness or your replacement config.
 
 For live reload during local development:
 
@@ -259,8 +262,10 @@ Transport behavior is intentionally simple:
 
 The core migrator also treats `migrate.ErrNoChange` as a successful no-op and still returns any accumulated logs.
 
-For gRPC requests that reach migration execution and then fail, the server also
-adds failure diagnostics as trailers:
+For gRPC requests that pass request validation and then fail, the server also
+adds failure diagnostics as trailers. This includes unknown database names and
+source/URL resolution failures as well as core migration failures; a zero
+version returns `InvalidArgument` before this trailer path runs.
 
 - `migration-error`: one of `not_found`, `canceled`, `deadline_exceeded`,
   `invalid_config`, `invalid_migration`, or `unknown`.
@@ -291,6 +296,12 @@ The sample test config also enables:
 - text logging,
 - Prometheus metrics, and
 - OTLP tracing with `http://localhost:4318/v1/traces`.
+
+GitHub migration sources have one health-check exception: `/healthz` parses a
+configured `github://` source but does not open the remote repository during the
+health check. The remote source is opened during migration execution, so GitHub
+reachability failures can still appear on a migration request after health has
+reported on the configured target.
 
 ## 🛠️ Development
 
@@ -333,7 +344,9 @@ The Ruby harness under `test/` assumes:
 
 - HTTP server on `http://localhost:11000`
 - gRPC server on `localhost:12000`
-- Postgres reachable on `localhost:5433`
+- Postgres reachable by the service on `localhost:5433`
+- A backing local Postgres instance on `localhost:5432` for the nonnative proxy
+  and direct harness cleanup/assertion helpers
 
 The feature harness process wiring lives in `test/nonnative.yml`.
 

--- a/api/migrieren/v1/service.proto
+++ b/api/migrieren/v1/service.proto
@@ -45,8 +45,10 @@ service Service {
   // databases, Canceled/DeadlineExceeded for stopped requests, and Internal for
   // configuration, source, database, or migration failures.
   //
-  // gRPC failures from migration execution include trailers when the request
-  // reaches the migrator:
+  // gRPC failures after request validation include trailers when the request
+  // reaches the transport migrator. This includes unknown database names and
+  // source/URL resolution failures; zero-version InvalidArgument responses do
+  // not use this trailer path.
   // - migration-error: not_found, canceled, deadline_exceeded, invalid_config,
   //   invalid_migration, or unknown.
   // - migration-log-count: the number of migration log lines returned.

--- a/api/migrieren/v1/service_grpc.pb.go
+++ b/api/migrieren/v1/service_grpc.pb.go
@@ -34,8 +34,10 @@ type ServiceClient interface {
 	// databases, Canceled/DeadlineExceeded for stopped requests, and Internal for
 	// configuration, source, database, or migration failures.
 	//
-	// gRPC failures from migration execution include trailers when the request
-	// reaches the migrator:
+	// gRPC failures after request validation include trailers when the request
+	// reaches the transport migrator. This includes unknown database names and
+	// source/URL resolution failures; zero-version InvalidArgument responses do
+	// not use this trailer path.
 	//   - migration-error: not_found, canceled, deadline_exceeded, invalid_config,
 	//     invalid_migration, or unknown.
 	//   - migration-log-count: the number of migration log lines returned.
@@ -74,8 +76,10 @@ type ServiceServer interface {
 	// databases, Canceled/DeadlineExceeded for stopped requests, and Internal for
 	// configuration, source, database, or migration failures.
 	//
-	// gRPC failures from migration execution include trailers when the request
-	// reaches the migrator:
+	// gRPC failures after request validation include trailers when the request
+	// reaches the transport migrator. This includes unknown database names and
+	// source/URL resolution failures; zero-version InvalidArgument responses do
+	// not use this trailer path.
 	//   - migration-error: not_found, canceled, deadline_exceeded, invalid_config,
 	//     invalid_migration, or unknown.
 	//   - migration-log-count: the number of migration log lines returned.

--- a/internal/api/migrate/migrate.go
+++ b/internal/api/migrate/migrate.go
@@ -54,6 +54,11 @@ func IsInvalidMigration(err error) bool {
 }
 
 // FailureKind returns a stable, safe diagnostic kind for err.
+//
+// The returned value is one of "not_found", "canceled", "deadline_exceeded",
+// "invalid_config", "invalid_migration", or "unknown". A context carrying
+// [FailureStageKey] is classified as "invalid_config" so source/URL resolution
+// failures are reported consistently by transports.
 func FailureKind(ctx context.Context, err error) string {
 	switch {
 	case IsNotFound(err):
@@ -106,6 +111,11 @@ type Migrator struct {
 // metadata, plus migration logs from the core migrator. If the database name
 // does not exist in the configuration, this returns an error that wraps
 // `internal/migrate.ErrNotFound` (detectable via [IsNotFound]).
+//
+// Source and URL resolution failures return the underlying filesystem error and
+// a derived context containing [FailureStageKey] set to [FailureStageSource] or
+// [FailureStageURL]. [FailureKind] maps those staged failures to
+// "invalid_config" for transport diagnostics.
 func (s *Migrator) Migrate(ctx context.Context, db string, version uint64) (context.Context, []string, error) {
 	d, err := s.config.Database(db)
 	if d == nil {

--- a/internal/api/v1/doc.go
+++ b/internal/api/v1/doc.go
@@ -1,0 +1,6 @@
+// Package v1 wires the versioned API surface into the service dependency graph.
+//
+// The package owns DI composition for the v1 transport adapters. The protobuf
+// contract itself lives in api/migrieren/v1, while transport-specific behavior
+// lives under the transport subpackages.
+package v1

--- a/internal/api/v1/transport/grpc/doc.go
+++ b/internal/api/v1/transport/grpc/doc.go
@@ -1,0 +1,6 @@
+// Package grpc implements the migrieren.v1 gRPC transport.
+//
+// It registers the generated service server, delegates migration work to the
+// transport-facing migrator, maps domain errors to gRPC status codes, and adds
+// safe failure diagnostics as trailers for post-validation migration failures.
+package grpc

--- a/internal/api/v1/transport/http/doc.go
+++ b/internal/api/v1/transport/http/doc.go
@@ -1,0 +1,6 @@
+// Package http registers the HTTP RPC facade for the migrieren.v1 API.
+//
+// The shared HTTP RPC runtime exposes the generated gRPC Migrate method at the
+// repository-documented HTTP route while keeping request handling delegated to
+// the gRPC transport implementation.
+package http

--- a/internal/cmd/doc.go
+++ b/internal/cmd/doc.go
@@ -1,0 +1,6 @@
+// Package cmd wires Migrieren commands into the shared service CLI.
+//
+// The package owns command registration and dependency-graph composition for
+// the server process; command behavior is documented through the README and the
+// shared CLI help surface.
+package cmd

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -10,6 +10,11 @@ import (
 //
 // It embeds the shared go-service configuration and adds service-specific
 // health and migration settings.
+//
+// Health, Migrate, and the embedded shared config are required runtime
+// sections. Configuration validation is expected to run before the DI projection
+// helpers below are called, so those helpers intentionally return the configured
+// sections directly instead of materializing empty fallback structs.
 type Config struct {
 	Health         *health.Config  `yaml:"health,omitempty" json:"health,omitempty" toml:"health,omitempty" validate:"required"`
 	Migrate        *migrate.Config `yaml:"migrate,omitempty" json:"migrate,omitempty" toml:"migrate,omitempty" validate:"required"`

--- a/internal/config/doc.go
+++ b/internal/config/doc.go
@@ -1,0 +1,6 @@
+// Package config defines Migrieren's top-level runtime configuration.
+//
+// It combines the shared go-service runtime config with service-specific health
+// and migration sections, then exposes projection helpers used by dependency
+// injection after validation has ensured the required sections are present.
+package config

--- a/internal/health/checker/doc.go
+++ b/internal/health/checker/doc.go
@@ -1,0 +1,6 @@
+// Package checker contains health check implementations for Migrieren.
+//
+// It provides a noop checker wrapper and a migration-target checker that
+// resolves configured source/database references, validates source syntax or
+// openness, and pings the configured database within the health timeout.
+package checker

--- a/internal/health/doc.go
+++ b/internal/health/doc.go
@@ -1,0 +1,6 @@
+// Package health registers service health checks and observers.
+//
+// The package installs service-level online/noop checks, per-database migration
+// target checks, and the intentionally narrower gRPC service health check used
+// by clients of migrieren.v1.Service.
+package health

--- a/internal/migrate/database/database.go
+++ b/internal/migrate/database/database.go
@@ -87,6 +87,15 @@ func openPGX(ctx context.Context, u *url.URL) (database.Driver, error) {
 }
 
 // Ping opens databaseURL and verifies that the database can be reached with ctx.
+//
+// It parses databaseURL with the same supported scheme set as [Open]. Empty,
+// malformed, and unsupported-scheme URLs return [ErrInvalidURL] or
+// [ErrUnsupportedDriver]. Driver-specific option parsing errors, telemetry open
+// errors, and ping failures are returned as-is.
+//
+// Ping opens a telemetry-instrumented database handle, calls PingContext with
+// ctx, and closes the handle before returning. It does not register DB stats
+// metrics or create a migrate database driver.
 func Ping(ctx context.Context, databaseURL string) error {
 	u, err := url.Parse(databaseURL)
 	if err != nil {

--- a/internal/migrate/database/doc.go
+++ b/internal/migrate/database/doc.go
@@ -1,0 +1,7 @@
+// Package database opens and checks migrate database drivers.
+//
+// The package owns supported database-driver selection for migration and health
+// paths. It currently accepts pgx5 URLs, rewrites them for the underlying
+// Postgres SQL driver, applies request-deadline statement timeouts, and wires
+// database telemetry around opened connections.
+package database

--- a/internal/migrate/pgx/doc.go
+++ b/internal/migrate/pgx/doc.go
@@ -1,0 +1,6 @@
+// Package pgx adapts golang-migrate's pgx v5 database driver.
+//
+// It parses Migrieren's supported pgx5 URL query parameters into the upstream
+// driver config and exposes the narrow driver-construction surface used by the
+// database package.
+package pgx

--- a/internal/migrate/source/doc.go
+++ b/internal/migrate/source/doc.go
@@ -1,0 +1,6 @@
+// Package source owns migration source driver wiring and validation.
+//
+// It registers the supported golang-migrate source drivers and provides a
+// bounded health-check path that avoids opening GitHub sources, because the
+// upstream GitHub driver does not expose a request-scoped timeout hook.
+package source

--- a/internal/migrate/source/source.go
+++ b/internal/migrate/source/source.go
@@ -38,7 +38,12 @@ func Check(ctx context.Context, sourceURL string) error {
 	return ctx.Err()
 }
 
-// Open opens a source driver.
+// Open opens a source driver using the upstream golang-migrate source registry.
+//
+// This package registers the file and GitHub source drivers via side-effect
+// imports. Open does not accept a context or per-call timeout; callers that need
+// bounded validation should use [Check], which intentionally avoids opening
+// GitHub sources during health checks.
 func Open(sourceURL string) (source.Driver, error) {
 	return source.Open(sourceURL)
 }

--- a/internal/migrate/telemetry/logger/doc.go
+++ b/internal/migrate/telemetry/logger/doc.go
@@ -1,0 +1,5 @@
+// Package logger captures golang-migrate log output for API responses.
+//
+// The logger is concurrency-safe, bounded in memory, and marks truncation so
+// transports can return recent migration logs without exposing unbounded output.
+package logger

--- a/internal/migrate/url/doc.go
+++ b/internal/migrate/url/doc.go
@@ -1,0 +1,6 @@
+// Package url parses and normalizes migration-related URLs.
+//
+// It rejects empty or schemeless values for configured source/database URLs and
+// converts Migrieren's pgx5 database URLs into the PostgreSQL URL shape consumed
+// by the underlying SQL driver.
+package url

--- a/test/lib/migrieren/pg.rb
+++ b/test/lib/migrieren/pg.rb
@@ -8,8 +8,10 @@ module Migrieren
   # by step definitions to perform direct database setup/teardown tasks outside
   # of the Migrieren API.
   #
-  # The helper connects to a local Postgres server using the `pg` gem with a
-  # fixed URI intended for the test environment.
+  # The helper connects directly to the backing local Postgres server using the
+  # `pg` gem with a fixed URI intended for the test environment. This direct
+  # connection uses `localhost:5432`; the service under test reaches the same
+  # database through the nonnative proxy configured at `localhost:5433`.
   #
   # @example Dropping test tables between scenarios
   #   Migrieren.pg.destroy
@@ -55,8 +57,9 @@ module Migrieren
     ##
     # Seeds the managed tables, then runs {#destroy}.
     #
-    # This verifies the cleanup path from the feature harness without modeling it
-    # as an application feature.
+    # This exercises the cleanup path from the feature harness without modeling
+    # it as an application feature. Callers must check {#destroyed?}, or use the
+    # support hook, to assert the cleanup postcondition.
     #
     # @return [void]
     def verify_destroy
@@ -117,6 +120,9 @@ module Migrieren
     ##
     # Returns the number of rows in the accounts fixture table.
     #
+    # This is intended for post-migration assertions. If `accounts` has not been
+    # created yet, the underlying `pg` exception is raised.
+    #
     # @return [Integer] row count
     def account_count
       @conn.exec('SELECT COUNT(*) FROM accounts').getvalue(0, 0).to_i
@@ -124,6 +130,10 @@ module Migrieren
 
     ##
     # Returns the current clean migration version from the configured migration table.
+    #
+    # This is intended for post-migration assertions. If
+    # `migrieren_schema_migrations` has not been created yet, the underlying `pg`
+    # exception is raised.
     #
     # @return [Integer, nil] the version, or nil when the table has no row
     def migration_version

--- a/test/lib/migrieren/v1/service_services_pb.rb
+++ b/test/lib/migrieren/v1/service_services_pb.rb
@@ -22,8 +22,10 @@ module Migrieren
         # databases, Canceled/DeadlineExceeded for stopped requests, and Internal for
         # configuration, source, database, or migration failures.
         #
-        # gRPC failures from migration execution include trailers when the request
-        # reaches the migrator:
+        # gRPC failures after request validation include trailers when the request
+        # reaches the transport migrator. This includes unknown database names and
+        # source/URL resolution failures; zero-version InvalidArgument responses do
+        # not use this trailer path.
         # - migration-error: not_found, canceled, deadline_exceeded, invalid_config,
         #   invalid_migration, or unknown.
         # - migration-log-count: the number of migration log lines returned.


### PR DESCRIPTION
## What

- Clarifies local harness Postgres topology, GitHub source health-check behavior, and gRPC failure trailer scope.
- Expands Go and Ruby API comments for config validation, failure metadata, database ping/source opening, and Postgres helper preconditions.
- Adds package docs for internal packages with exported composition, transport, health, driver, logger, and URL responsibilities, and regenerates protobuf Go/Ruby service comments from the proto source.

## Why

- Reduces operator and client confusion around local setup, health semantics, and diagnostic metadata boundaries.
- Preserves maintainer-facing contracts that are easy to miss when changing config projection, transport diagnostics, database health checks, source handling, or feature harness helpers.

## Testing

- `make proto-generate` - passed
- `make proto-lint` - passed
- `git diff --check` - passed
- `make lint` - passed
- `make proto-stale` - not run before review because the target requires a clean working tree and this PR is intentionally still uncommitted at validation time; generated stubs were refreshed with `make proto-generate`.
