### PR TITLE
docs(readme): clarify migration setup and api contracts

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,18 @@ This builds `./migrieren` in the repository root.
 > to a backing Postgres instance on `localhost:5432`; both ports must line up
 > with either the local harness or your replacement config.
 
+If you use this repository's shared local Docker environment, start and stop it with:
+
+```sh
+make start
+make stop
+```
+
+Those targets manage the shared sibling Docker checkout and may require SSH access
+to that repository. If you do not use them, provide an equivalent local Postgres
+database named `test` with user/password `test:test` on `localhost:5432`; the
+feature harness exposes it to the service through the proxy on `localhost:5433`.
+
 For live reload during local development:
 
 ```sh
@@ -93,6 +105,15 @@ The API accepts a logical database name such as `postgres`. The service then:
 4. Passes the resolved source URL and database URL to the core migrator.
 
 That means `source` and `url` in the YAML config are usually references to files or other resolvable inputs, not the final literal migration/source strings themselves.
+
+The resolver accepts the shared go-service source-string forms:
+
+- `env:NAME`: reads the value of environment variable `NAME`. An omitted or
+  unset variable fails resolution; an explicitly empty variable resolves to an
+  empty value.
+- `file:<path>`: reads the file at `<path>`. Relative paths are resolved from
+  the server process working directory.
+- any other value: used as the literal migration source URL or database URL.
 
 ## ⚙️ Configuration
 
@@ -242,6 +263,14 @@ Content-Type: application/json
 }
 ```
 
+Copy-paste request against the local HTTP façade:
+
+```sh
+curl -sS -X POST http://localhost:11000/migrieren.v1.Service/Migrate \
+  -H 'Content-Type: application/json' \
+  -d '{"database":"postgres","version":1}'
+```
+
 ### 🚦 Error mapping
 
 Transport behavior is intentionally simple:
@@ -257,8 +286,10 @@ Transport behavior is intentionally simple:
   - HTTP: `500`
 - Request canceled by the caller:
   - gRPC: `Canceled`
+  - HTTP: `499` (`Client Closed Request`, non-standard)
 - Request deadline exceeded:
   - gRPC: `DeadlineExceeded`
+  - HTTP: `504`
 
 The core migrator also treats `migrate.ErrNoChange` as a successful no-op and still returns any accumulated logs.
 

--- a/internal/api/migrate/migrate.go
+++ b/internal/api/migrate/migrate.go
@@ -107,6 +107,10 @@ type Migrator struct {
 // database URL are read via the filesystem abstraction, then passed to the core
 // migrator.
 //
+// This adapter does not perform public request validation such as rejecting a
+// zero version; transport callers that expose the migrieren.v1 API must enforce
+// that contract before calling Migrate.
+//
 // Returns the input context, or a derived context when the core migrator adds
 // metadata, plus migration logs from the core migrator. If the database name
 // does not exist in the configuration, this returns an error that wraps

--- a/internal/migrate/database/database.go
+++ b/internal/migrate/database/database.go
@@ -35,6 +35,9 @@ var telemetryAttrs = telemetry.WithAttributes(attributes.DBSystemNamePostgreSQL)
 // telemetry.RegisterDBStatsMetrics are returned to the caller. Migration paths
 // map those setup failures through the core migrator's invalid-config error,
 // while health/ping paths return the underlying setup or connectivity error.
+//
+// Callers own the returned driver and must close it. Closing releases the
+// underlying database driver and unregisters DB stats metrics.
 func Open(ctx context.Context, databaseURL string) (database.Driver, error) {
 	u, err := url.Parse(databaseURL)
 	if err != nil {

--- a/internal/migrate/migrate.go
+++ b/internal/migrate/migrate.go
@@ -54,7 +54,9 @@ type Migrator struct{}
 //   - ctx: a service context used for metadata/telemetry.
 //   - src: migration source URL (for example "file://...").
 //   - db: database URL (for example a Postgres URL).
-//   - version: the target migration version.
+//   - version: the target migration version. Public API callers must reject
+//     zero before calling Migrate; this method forwards the value to
+//     golang-migrate.
 //
 // Output:
 //   - ctx: the input context, or a derived context containing "migrateError" when

--- a/internal/migrate/source/source.go
+++ b/internal/migrate/source/source.go
@@ -44,6 +44,8 @@ func Check(ctx context.Context, sourceURL string) error {
 // imports. Open does not accept a context or per-call timeout; callers that need
 // bounded validation should use [Check], which intentionally avoids opening
 // GitHub sources during health checks.
+//
+// Callers own the returned driver and must close it after successful opens.
 func Open(sourceURL string) (source.Driver, error) {
 	return source.Open(sourceURL)
 }

--- a/internal/migrate/url/url.go
+++ b/internal/migrate/url/url.go
@@ -29,6 +29,9 @@ func Parse(raw string) (*URL, error) {
 
 // DatabaseURL converts a pgx5 migrate URL into the PostgreSQL URL consumed
 // by the underlying SQL driver.
+//
+// It also removes golang-migrate custom query parameters, so migration-only
+// options such as x-migrations-table are not passed to the SQL driver.
 func DatabaseURL(u *URL) string {
 	dbURL := *u
 	dbURL.Scheme = "postgres"


### PR DESCRIPTION
## What

- Clarify local bootstrap for the checked-in test config, including the shared Docker start/stop targets and the Postgres/proxy port contract.
- Document migration `source` and `url` resolver forms, add a copy-paste HTTP migrate request, and complete the HTTP cancellation/deadline status mapping.
- Add GoDoc for internal migrator validation boundaries, driver cleanup ownership, and migration URL filtering.

## Why

- First-use and API consumers previously had to infer local service dependencies, supported config sources, and HTTP lifecycle failures from implementation details.
- Capturing those contracts at the README and GoDoc surfaces reduces misconfiguration and maintenance mistakes without changing runtime behavior.

## Testing

- `make help` - passed
- `make -n start` - passed
- `make -n features` - passed
- `git diff --check` - passed
- `make lint` - passed
