### PR TITLE
test(feature): centralize harness request options

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ vendor
 dist
 .source-key
 ISSUES.md
+FEATURES.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -115,6 +115,14 @@ This refreshes Go modules and updates `vendor/` (and also ensures Ruby gems for 
   Only raise a finding when there is concrete evidence of dependency drift that
   the normal repo workflow failed to capture.
 
+### Local CI preflight target belongs in shared bin tooling
+
+- This repository consumes shared Make targets from the `bin/` submodule.
+- If a one-command local CI preflight target is needed, it should be added to
+  the shared `bin` Make fragments rather than as a service-local target here.
+- Reviewers should not flag the lack of a root `verify`/`ci-checks` target in
+  this repository as a feature gap by default.
+
 ### Linting Ruby code
 
 Feature-test Ruby linting is typically run via:
@@ -124,6 +132,16 @@ make -C test lint
 ```
 
 (Directly invoking bundler/rubocop may not work unless run through the repo’s Makefile wiring.)
+
+### Ruby feature harness endpoints are local by design
+
+- The Ruby code under `test/` is a local feature-test harness, not production
+  service code.
+- Fixed localhost endpoints in `test/lib/**`, `test/nonnative.yml`, and related
+  feature helpers are intentional local harness assumptions unless there is
+  concrete evidence of current workflow breakage.
+- Reviewers should not flag the lack of environment-configurable HTTP, gRPC,
+  observability, or direct Postgres endpoints as a feature gap by default.
 
 ## 0) First check
 

--- a/test/Makefile
+++ b/test/Makefile
@@ -1,1 +1,2 @@
+include ../bin/build/make/help.mak
 include ../bin/build/make/ruby.mak

--- a/test/features/step_definitions/health/transport/http/observability_steps.rb
+++ b/test/features/step_definitions/health/transport/http/observability_steps.rb
@@ -2,10 +2,7 @@
 
 When('the system requests the {string} with HTTP') do |name|
   @observability_name = name
-  @observability_opts = {
-    headers: { request_id: SecureRandom.uuid },
-    read_timeout: 10, open_timeout: 10
-  }
+  @observability_opts = Migrieren.http_options
 end
 
 Then('the system should respond with a healthy status with HTTP') do

--- a/test/features/step_definitions/v1/transport/http/api_steps.rb
+++ b/test/features/step_definitions/v1/transport/http/api_steps.rb
@@ -34,13 +34,12 @@ end
 
 def request_with_http(table)
   rows = table.rows_hash
-  opts = {
+  opts = Migrieren.http_options(
     headers: {
-      request_id: SecureRandom.uuid, user_agent: 'Migrieren-ruby-client/1.0 HTTP/1.0',
+      user_agent: 'Migrieren-ruby-client/1.0 HTTP/1.0',
       content_type: :json, accept: :json
-    },
-    read_timeout: 10, open_timeout: 10
-  }
+    }
+  )
 
   Migrieren::V1.server_http.migrate(rows['database'], rows['version'].to_i, opts)
 end

--- a/test/features/step_definitions/v1/transport/http/benchmark_steps.rb
+++ b/test/features/step_definitions/v1/transport/http/benchmark_steps.rb
@@ -1,13 +1,12 @@
 # frozen_string_literal: true
 
 When('I request to migrate with HTTP which performs in {int} ms') do |time|
-  opts = {
+  opts = Migrieren.http_options(
     headers: {
-      request_id: SecureRandom.uuid, user_agent: 'Bezeichner-ruby-client/1.0 HTTP/1.0',
+      user_agent: 'Bezeichner-ruby-client/1.0 HTTP/1.0',
       content_type: :json, accept: :json
-    },
-    read_timeout: 10, open_timeout: 10
-  }
+    }
+  )
 
   expect do
     response = Migrieren::V1.server_http.migrate('postgres', rand(1..2), opts)

--- a/test/lib/migrieren.rb
+++ b/test/lib/migrieren.rb
@@ -113,6 +113,25 @@ module Migrieren
         deadline: deadline || (Time.now + 6)
       }
     end
+
+    ##
+    # Returns bounded per-call options for HTTP feature-harness requests.
+    #
+    # Each call includes a generated `request_id` header. Caller-provided
+    # headers are merged afterward, so scenarios can override that value or add
+    # transport-specific headers such as content type and user agent.
+    #
+    # @param headers [Hash] HTTP headers merged after the generated request id
+    # @param read_timeout [Integer] read timeout in seconds
+    # @param open_timeout [Integer] connection open timeout in seconds
+    # @return [Hash] options compatible with `Nonnative::HTTPClient` calls
+    def http_options(headers: {}, read_timeout: 10, open_timeout: 10)
+      {
+        headers: { request_id: SecureRandom.uuid }.merge(headers),
+        read_timeout:,
+        open_timeout:
+      }
+    end
   end
 
   ##


### PR DESCRIPTION
## What

- Add repository guidance that keeps local feature-harness endpoint assumptions and shared-bin CI preflight ownership from resurfacing as feature gaps.
- Ignore the temporary feature-gap ledger file and expose help output from the Ruby harness Makefile.
- Centralize HTTP feature-harness request options behind `Migrieren.http_options` and use it from HTTP migration, benchmark, and observability steps.

## Why

- Reviewers need durable repo-local guidance for accepted boundaries so future gap passes focus on actionable service work.
- The Ruby harness command surface should be discoverable from `test/` in the same way as other shared Make targets.
- Shared HTTP request options reduce repeated setup while preserving generated request IDs, timeouts, and caller-specific headers.

## Testing

- `make lint` - passed
- `make features` - passed, covering 45 scenarios and 99 steps
- `make -C test help` - passed
- `git diff --check` - passed
