### PR TITLE
build(ci): tighten project workflow defaults

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,23 +22,23 @@ jobs:
       - restore_cache:
           name: restore go cache
           keys:
-            - migrieren-go-cache-{{ checksum "go.sum" }}-{{ checksum "~/.go-version" }}-{{ checksum ".source-key" }}
+            - migrieren-go-cache-{{ checksum "go.sum" }}-{{ checksum "~/.go-version" }}
             - migrieren-go-cache-
       - restore_cache:
           name: restore ruby cache
           keys:
-            - migrieren-ruby-cache-{{ checksum "test/Gemfile.lock" }}-{{ checksum "~/.ruby-version" }}-{{ checksum ".source-key" }}
+            - migrieren-ruby-cache-{{ checksum "test/Gemfile.lock" }}-{{ checksum "~/.ruby-version" }}
             - migrieren-ruby-cache-
       - run: make clean
       - run: make dep
       - save_cache:
           name: save go cache
-          key: migrieren-go-cache-{{ checksum "go.sum" }}-{{ checksum "~/.go-version" }}-{{ checksum ".source-key" }}
+          key: migrieren-go-cache-{{ checksum "go.sum" }}-{{ checksum "~/.go-version" }}
           paths:
             - ~/go/pkg/mod
       - save_cache:
           name: save ruby cache
-          key: migrieren-ruby-cache-{{ checksum "test/Gemfile.lock" }}-{{ checksum "~/.ruby-version" }}-{{ checksum ".source-key" }}
+          key: migrieren-ruby-cache-{{ checksum "test/Gemfile.lock" }}-{{ checksum "~/.ruby-version" }}
           paths:
             - test/vendor
       - restore_cache:
@@ -100,7 +100,7 @@ jobs:
       - restore_cache:
           name: restore go cache
           keys:
-            - migrieren-go-cache-{{ checksum "go.sum" }}-{{ checksum "~/.go-version" }}-{{ checksum ".source-key" }}
+            - migrieren-go-cache-{{ checksum "go.sum" }}-{{ checksum "~/.go-version" }}
             - migrieren-go-cache-
       - restore_cache:
           name: restore go build cache

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ dist
 .source-key
 ISSUES.md
 FEATURES.md
+PROJECTS.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -103,6 +103,18 @@ This refreshes Go modules and updates `vendor/` (and also ensures Ruby gems for 
   bypassed scanning, a confirmed side-effecting rerun problem, or an operator
   rollback/reproducibility incident.
 
+### GoReleaser config validation is owned by the release image
+
+- CircleCI's `version` job runs the external `package` command from
+  `alexfalkowski/release` / `alexfalkowski/docker/release`.
+- That release image's `release/package` script runs
+  `goreleaser check "$releaser"` before `goreleaser release`.
+- Reviewers should not flag the absence of a separate repository-local
+  GoReleaser config validation job as a project gap by default. Only raise it
+  with concrete evidence that the release image no longer validates
+  `.goreleaser.yml`, or that this repository has explicitly decided to own a
+  pre-release GoReleaser check locally.
+
 ### Dependency setup drift is covered by repo workflow
 
 - Dependency changes are expected to go through the repository Make targets from
@@ -132,6 +144,19 @@ make -C test lint
 ```
 
 (Directly invoking bundler/rubocop may not work unless run through the repo’s Makefile wiring.)
+
+### Ruby runtime selection is owned by the Ruby CI image
+
+- The Ruby code under `test/` is feature-test harness code, not production
+  service code.
+- Ruby runtime selection for this harness is controlled by the external
+  `alexfalkowski/ruby` image from `alexfalkowski/docker/ruby`, which is the Ruby
+  project CI tooling image.
+- Reviewers should not flag the absence of a repository-local `.ruby-version`,
+  `.tool-versions`, `mise.toml`, or Gemfile `ruby` directive as a project gap by
+  default. Only raise it with concrete evidence that the Ruby CI image no
+  longer supplies the expected runtime, or that this repository has explicitly
+  decided to own Ruby version selection locally for the test harness.
 
 ### Ruby feature harness endpoints are local by design
 

--- a/api/Makefile
+++ b/api/Makefile
@@ -1,1 +1,2 @@
 include ../bin/build/make/buf.mak
+include ../bin/build/make/help.mak


### PR DESCRIPTION
## What

- Narrow CircleCI dependency cache keys so Go module and Ruby bundle caches no longer depend on the broad repository source hash.
- Keep source-sensitive invalidation for Go build and lint caches.
- Add shared help discovery to the API Makefile while preserving the existing default API lint dry-run behavior.
- Capture repository review guardrails for GoReleaser validation and Ruby runtime ownership in AGENTS.md.

## Why

- Reduces unnecessary dependency cache churn from unrelated source, docs, config, or fixture edits.
- Makes API subdirectory commands discoverable the same way root and test commands are.
- Prevents future project-gap reviews from resurfacing release-image and Ruby-image responsibilities as local repository work.

## Testing

- `circleci config validate .circleci/config.yml` - passed
- `make -C api help` - passed
- `make -C test help` - passed
- `make -C api -n` - passed
- `make -C api -n lint` - passed
- `make -C api -n generate` - passed
- `make -C api -n breaking` - passed
- `make -C api -n format` - passed
- `git diff --check` - passed

AI-assisted-by: [Codex](https://openai.com/codex/)
