### PR TITLE
docs(reliability): record accepted migration and health conventions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ dist
 ISSUES.md
 FEATURES.md
 PROJECTS.md
+RELIABILITY.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -83,6 +83,30 @@ This refreshes Go modules and updates `vendor/` (and also ensures Ruby gems for 
   upstream-supported hook becomes available, or the project explicitly decides
   to own a local GitHub source wrapper.
 
+### pgx advisory lock timeout behavior is an accepted library shortcoming
+
+- The wired Postgres migration path uses the upstream `golang-migrate/migrate`
+  pgx driver through `pgx.WithInstance(...)`.
+- That upstream constructor path can call `ensureVersionTable` and acquire the
+  migration advisory lock before Migrieren reaches its request-context-aware
+  migration goroutine.
+- Do not keep resurfacing that constructor-time advisory lock wait as a
+  repository-owned reliability gap by default. Treat it as an accepted upstream
+  library shortcoming unless there is concrete production evidence, a simpler
+  upstream-supported hook becomes available, or the project explicitly decides
+  to own a local pgx driver wrapper/fork.
+
+### Health probe names are reserved by convention
+
+- Health wiring uses internal probe names such as `noop` and `online`.
+- Migration database names are not currently validation-blocked from using
+  those values, but those names are reserved by convention and are documented as
+  such.
+- Reviewers should not keep resurfacing the hypothetical `noop`/`online`
+  database-name collision as a reliability gap by default. Only raise it with
+  concrete evidence of production/config misuse, or if the project explicitly
+  decides to enforce reserved health probe names in config validation.
+
 ### CI uses latest Mimir image by design
 
 - CircleCI currently uses `grafana/mimir:latest` for the auxiliary Mimir service

--- a/README.md
+++ b/README.md
@@ -202,6 +202,12 @@ parameters:
 
 Malformed boolean or integer values reject the configured database URL.
 
+The upstream `golang-migrate` pgx driver can acquire its migration advisory lock
+while constructing the database driver. That constructor path does not expose
+Migrieren's request context, so request cancellation and deadlines should not be
+treated as a strict bound for every advisory-lock wait. Migrieren relies on the
+upstream driver behavior here rather than maintaining a local pgx driver fork.
+
 ### 🧪 About the checked-in test config
 
 `test/.config/server.yml` intentionally contains both valid and invalid database definitions:
@@ -321,6 +327,10 @@ There is an important detail in the checked-in test config:
 - gRPC health for `migrieren.v1.Service` reports `SERVING`.
 - HTTP `/livez` and `/readyz` report healthy.
 - HTTP `/healthz` is expected to be unhealthy because the test config deliberately registers invalid database entries for failure-path coverage.
+
+Health probes use internal registration names such as `noop` and `online`.
+Treat those names as reserved for health wiring rather than as migration
+database names.
 
 The sample test config also enables:
 


### PR DESCRIPTION
## What

- Document that the upstream `golang-migrate` pgx constructor can acquire advisory locks before Migrieren can apply request-context cancellation, and that the project relies on that upstream behavior instead of owning a local fork.
- Document `noop` and `online` as reserved health wiring names rather than migration database names.
- Add `RELIABILITY.md` to the ignore list so temporary scoped reliability ledgers from gap reviews are not committed.

## Why

- Captures accepted operational boundaries from the reliability review so future reviewers do not keep reopening intentionally deferred or convention-based items.
- Keeps user-facing operational notes and agent review guidance aligned on migration driver ownership and health probe naming conventions.

## Testing

- `git diff --check` - passed
- Service tests not run; the change is documentation and ignore-list housekeeping only.
