### PR TITLE
build(ci): reuse pipeline setup

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,18 @@
 version: 2.1
 
-jobs:
-  build-service:
+commands:
+  sync-submodules:
+    steps:
+      - run: git submodule sync
+      - run: git submodule update --init
+  checkout-submodules:
+    steps:
+      - checkout:
+          method: blobless
+      - sync-submodules
+
+executors:
+  go-with-postgres-mimir:
     docker:
       - image: alexfalkowski/go:4.20
       - image: postgres:18-trixie
@@ -11,12 +22,22 @@ jobs:
           POSTGRES_PASSWORD: test
       - image: grafana/mimir:latest
         command: -server.http-listen-port=9009 -auth.multitenancy-enabled=false -ingester.ring.replication-factor=1
+  release:
+    docker:
+      - image: alexfalkowski/release:8.18
+  alpine:
+    docker:
+      - image: alpine:latest
+  go:
+    docker:
+      - image: alexfalkowski/go:4.20
+
+jobs:
+  build-service:
+    executor: go-with-postgres-mimir
     working_directory: ~/migrieren
     steps:
-      - checkout:
-          method: blobless
-      - run: git submodule sync
-      - run: git submodule update --init
+      - checkout-submodules
       - run: make source-key
       - run: dockerize -wait tcp://localhost:5432 -wait tcp://localhost:9009 -timeout 1m
       - restore_cache:
@@ -77,25 +98,17 @@ jobs:
       - run: make codecov-upload
     resource_class: arm.large
   sync:
-    docker:
-      - image: alexfalkowski/release:8.18
+    executor: release
     working_directory: ~/migrieren
     steps:
-      - checkout:
-          method: blobless
-      - run: git submodule sync
-      - run: git submodule update --init
+      - checkout-submodules
       - run: make sync push
     resource_class: arm.large
   version:
-    docker:
-      - image: alexfalkowski/release:8.18
+    executor: release
     working_directory: ~/migrieren
     steps:
-      - checkout:
-          method: blobless
-      - run: git submodule sync
-      - run: git submodule update --init
+      - checkout-submodules
       - run: make source-key
       - restore_cache:
           name: restore go cache
@@ -115,46 +128,33 @@ jobs:
       - run: package
     resource_class: arm.large
   wait-all:
-    docker:
-      - image: alpine:latest
+    executor: alpine
     resource_class: small
     steps:
       - run: echo "all applicable jobs finished"
   test-docker-amd64:
-    docker:
-      - image: alexfalkowski/go:4.20
+    executor: go
     working_directory: ~/migrieren
     steps:
-      - checkout:
-          method: blobless
-      - run: git submodule sync
-      - run: git submodule update --init
+      - checkout-submodules
       - setup_remote_docker:
           docker_layer_caching: true
       - run: make platform=amd64 test-docker
     resource_class: large
   test-docker-arm64:
-    docker:
-      - image: alexfalkowski/go:4.20
+    executor: go
     working_directory: ~/migrieren
     steps:
-      - checkout:
-          method: blobless
-      - run: git submodule sync
-      - run: git submodule update --init
+      - checkout-submodules
       - setup_remote_docker:
           docker_layer_caching: true
       - run: make platform=arm64 test-docker
     resource_class: arm.large
   release-docker-amd64:
-    docker:
-      - image: alexfalkowski/go:4.20
+    executor: go
     working_directory: ~/migrieren
     steps:
-      - checkout:
-          method: blobless
-      - run: git submodule sync
-      - run: git submodule update --init
+      - checkout-submodules
       - attach_workspace:
           at: /tmp/workspace
       - setup_remote_docker:
@@ -165,14 +165,10 @@ jobs:
       - run: make platform=amd64 release-docker
     resource_class: large
   release-docker-arm64:
-    docker:
-      - image: alexfalkowski/go:4.20
+    executor: go
     working_directory: ~/migrieren
     steps:
-      - checkout:
-          method: blobless
-      - run: git submodule sync
-      - run: git submodule update --init
+      - checkout-submodules
       - attach_workspace:
           at: /tmp/workspace
       - setup_remote_docker:
@@ -183,14 +179,10 @@ jobs:
       - run: make platform=arm64 release-docker
     resource_class: arm.large
   manifest-docker:
-    docker:
-      - image: alexfalkowski/go:4.20
+    executor: go
     working_directory: ~/migrieren
     steps:
-      - checkout:
-          method: blobless
-      - run: git submodule sync
-      - run: git submodule update --init
+      - checkout-submodules
       - attach_workspace:
           at: /tmp/workspace
       - setup_remote_docker:


### PR DESCRIPTION
## What

- Added reusable CircleCI commands for checkout and submodule setup.
- Added reusable CircleCI executors for the existing job images.
- Kept the existing job names, workflow dependencies, contexts, filters, resource classes, and command invocations unchanged.

## Why

- This reduces repeated CircleCI image and bootstrap configuration so cross-repo CI image updates are easier to review and less error-prone.

## Testing

- `circleci config validate` - passed for changed CircleCI config files.
- `git diff --check -- .circleci` - passed.
