### PR TITLE
feat(migrate): harden version and quoted table guards

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,7 +215,7 @@ upstream driver behavior here rather than maintaining a local pgx driver fork.
 - `postgres` and `github` are used for successful migration scenarios.
 - `timeout` is used for deadline and cancellation scenarios.
 - `logs` is used for bounded migration log scenarios.
-- `missing_source`, `invalid_source`, `missing_url`, `invalid_url`, `invalid_db`, and `invalid_port` exist to exercise failure paths in feature tests.
+- `missing_source`, `invalid_source`, `missing_url`, `invalid_url`, `invalid_db`, `invalid_quoted_table`, and `invalid_port` exist to exercise failure paths in feature tests.
 
 > [!IMPORTANT]
 > The checked-in config is a test fixture. Use it for local development and feature coverage, but do not treat it as a healthy production config.
@@ -235,7 +235,7 @@ The service exposes:
 Request:
 
 - `database`: logical database name from config.
-- `version`: target migration version as `uint64`; must be greater than `0`.
+- `version`: target migration version as `uint64`; must be between `1` and the server-supported signed integer maximum.
 
 Response:
 
@@ -281,7 +281,7 @@ curl -sS -X POST http://localhost:11000/migrieren.v1.Service/Migrate \
 
 Transport behavior is intentionally simple:
 
-- Zero migration version:
+- Migration version outside the supported range:
   - gRPC: `InvalidArgument`
   - HTTP: `400`
 - Unknown database name:
@@ -301,8 +301,8 @@ The core migrator also treats `migrate.ErrNoChange` as a successful no-op and st
 
 For gRPC requests that pass request validation and then fail, the server also
 adds failure diagnostics as trailers. This includes unknown database names and
-source/URL resolution failures as well as core migration failures; a zero
-version returns `InvalidArgument` before this trailer path runs.
+source/URL resolution failures as well as core migration failures; invalid
+version values return `InvalidArgument` before this trailer path runs.
 
 - `migration-error`: one of `not_found`, `canceled`, `deadline_exceeded`,
   `invalid_config`, `invalid_migration`, or `unknown`.

--- a/api/migrieren/v1/service.pb.go
+++ b/api/migrieren/v1/service.pb.go
@@ -92,7 +92,8 @@ type MigrateRequest struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// database is the configured logical database name, not a raw database URL.
 	Database string `protobuf:"bytes,1,opt,name=database,proto3" json:"database,omitempty"`
-	// version is the target migration version. It must be greater than zero.
+	// version is the target migration version. It must be greater than zero and
+	// fit within the server-supported signed integer range.
 	Version       uint64 `protobuf:"varint,2,opt,name=version,proto3" json:"version,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache

--- a/api/migrieren/v1/service.proto
+++ b/api/migrieren/v1/service.proto
@@ -24,7 +24,8 @@ message MigrateRequest {
   // database is the configured logical database name, not a raw database URL.
   string database = 1;
 
-  // version is the target migration version. It must be greater than zero.
+  // version is the target migration version. It must be greater than zero and
+  // fit within the server-supported signed integer range.
   uint64 version = 2;
 }
 
@@ -41,14 +42,15 @@ message MigrateResponse {
 service Service {
   // Migrate migrates a configured database to the requested version.
   //
-  // Errors use InvalidArgument for zero versions, NotFound for unknown
-  // databases, Canceled/DeadlineExceeded for stopped requests, and Internal for
-  // configuration, source, database, or migration failures.
+  // Errors use InvalidArgument for versions outside the supported range,
+  // NotFound for unknown databases, Canceled/DeadlineExceeded for stopped
+  // requests, and Internal for configuration, source, database, or migration
+  // failures.
   //
   // gRPC failures after request validation include trailers when the request
   // reaches the transport migrator. This includes unknown database names and
-  // source/URL resolution failures; zero-version InvalidArgument responses do
-  // not use this trailer path.
+  // source/URL resolution failures; pre-migration validation InvalidArgument
+  // responses do not use this trailer path.
   // - migration-error: not_found, canceled, deadline_exceeded, invalid_config,
   //   invalid_migration, or unknown.
   // - migration-log-count: the number of migration log lines returned.

--- a/api/migrieren/v1/service_grpc.pb.go
+++ b/api/migrieren/v1/service_grpc.pb.go
@@ -30,14 +30,15 @@ const (
 type ServiceClient interface {
 	// Migrate migrates a configured database to the requested version.
 	//
-	// Errors use InvalidArgument for zero versions, NotFound for unknown
-	// databases, Canceled/DeadlineExceeded for stopped requests, and Internal for
-	// configuration, source, database, or migration failures.
+	// Errors use InvalidArgument for versions outside the supported range,
+	// NotFound for unknown databases, Canceled/DeadlineExceeded for stopped
+	// requests, and Internal for configuration, source, database, or migration
+	// failures.
 	//
 	// gRPC failures after request validation include trailers when the request
 	// reaches the transport migrator. This includes unknown database names and
-	// source/URL resolution failures; zero-version InvalidArgument responses do
-	// not use this trailer path.
+	// source/URL resolution failures; pre-migration validation InvalidArgument
+	// responses do not use this trailer path.
 	//   - migration-error: not_found, canceled, deadline_exceeded, invalid_config,
 	//     invalid_migration, or unknown.
 	//   - migration-log-count: the number of migration log lines returned.
@@ -72,14 +73,15 @@ func (c *serviceClient) Migrate(ctx context.Context, in *MigrateRequest, opts ..
 type ServiceServer interface {
 	// Migrate migrates a configured database to the requested version.
 	//
-	// Errors use InvalidArgument for zero versions, NotFound for unknown
-	// databases, Canceled/DeadlineExceeded for stopped requests, and Internal for
-	// configuration, source, database, or migration failures.
+	// Errors use InvalidArgument for versions outside the supported range,
+	// NotFound for unknown databases, Canceled/DeadlineExceeded for stopped
+	// requests, and Internal for configuration, source, database, or migration
+	// failures.
 	//
 	// gRPC failures after request validation include trailers when the request
 	// reaches the transport migrator. This includes unknown database names and
-	// source/URL resolution failures; zero-version InvalidArgument responses do
-	// not use this trailer path.
+	// source/URL resolution failures; pre-migration validation InvalidArgument
+	// responses do not use this trailer path.
 	//   - migration-error: not_found, canceled, deadline_exceeded, invalid_config,
 	//     invalid_migration, or unknown.
 	//   - migration-log-count: the number of migration log lines returned.

--- a/internal/api/v1/transport/grpc/migrate.go
+++ b/internal/api/v1/transport/grpc/migrate.go
@@ -1,6 +1,7 @@
 package grpc
 
 import (
+	"math"
 	"strconv"
 
 	"github.com/alexfalkowski/go-service/v2/context"
@@ -26,8 +27,8 @@ func (s *Server) Migrate(ctx context.Context, req *v1.MigrateRequest) (*v1.Migra
 		},
 	}
 
-	if ver == 0 {
-		return resp, status.Error(codes.InvalidArgument, "version must be greater than zero")
+	if ver == 0 || ver > math.MaxInt {
+		return resp, status.Error(codes.InvalidArgument, "version must be between 1 and math.MaxInt")
 	}
 
 	ctx, logs, err := s.migrator.Migrate(ctx, db, ver)

--- a/internal/migrate/database/database.go
+++ b/internal/migrate/database/database.go
@@ -75,6 +75,8 @@ func openPGX(ctx context.Context, u *url.URL) (database.Driver, error) {
 
 	reg, err := telemetry.RegisterDBStatsMetrics(db, telemetryAttrs)
 	if err != nil {
+		_ = db.Close()
+
 		return nil, err
 	}
 

--- a/internal/migrate/pgx/pgx.go
+++ b/internal/migrate/pgx/pgx.go
@@ -78,7 +78,7 @@ func parseMigrationsTableOptions(query url.Values) (string, bool, error) {
 	if err != nil {
 		return "", false, fmt.Errorf("unable to parse option x-migrations-table-quoted: %w", err)
 	}
-	if migrationsTable != "" && migrationsTableQuoted && (migrationsTable[0] != '"' || migrationsTable[len(migrationsTable)-1] != '"') {
+	if migrationsTableQuoted && (migrationsTable == "" || migrationsTable[0] != '"' || migrationsTable[len(migrationsTable)-1] != '"') {
 		return "", false, fmt.Errorf(
 			"%w: x-migrations-table must be quoted when x-migrations-table-quoted is enabled, current value is %q",
 			ErrInvalidMigrationsTable, migrationsTable,

--- a/test/.config/server.yml
+++ b/test/.config/server.yml
@@ -24,6 +24,9 @@ migrate:
     - name: invalid_db
       source: file:secrets/source
       url: file:secrets/invalid_db
+    - name: invalid_quoted_table
+      source: file:secrets/source
+      url: file:secrets/invalid_quoted_table
     - name: invalid_port
       source: file:secrets/source
       url: file:secrets/invalid_port

--- a/test/features/v1/transport/grpc/api.feature
+++ b/test/features/v1/transport/grpc/api.feature
@@ -29,11 +29,16 @@ Feature: gRPC API
       | database | version |
       | missing  |       1 |
 
-  Scenario: Reject zero migration version
+  Scenario Outline: Reject <case> migration version
     When I request to migrate with gRPC:
-      | database | postgres |
-      | version  |        0 |
+      | database | postgres  |
+      | version  | <version> |
     Then I should receive an invalid argument migration from gRPC
+
+    Examples:
+      | case      | version             |
+      | zero      |                   0 |
+      | oversized | 9223372036854775808 |
 
   @clean
   Scenario: Stop migration when request deadline expires
@@ -83,14 +88,15 @@ Feature: gRPC API
     Then I should receive an invalid migration from gRPC
 
     Examples:
-      | database       | version |
-      | missing_source |       1 |
-      | invalid_source |       1 |
-      | missing_url    |       1 |
-      | invalid_url    |       1 |
-      | invalid_db     |       1 |
-      | invalid_port   |       1 |
-      | postgres       |       3 |
+      | database             | version |
+      | missing_source       |       1 |
+      | invalid_source       |       1 |
+      | missing_url          |       1 |
+      | invalid_url          |       1 |
+      | invalid_db           |       1 |
+      | invalid_quoted_table |       1 |
+      | invalid_port         |       1 |
+      | postgres             |       3 |
 
   @reset
   Scenario: Migrate erroneous databases

--- a/test/features/v1/transport/http/api.feature
+++ b/test/features/v1/transport/http/api.feature
@@ -29,11 +29,16 @@ Feature: HTTP API
       | database | version |
       | missing  |       1 |
 
-  Scenario: Reject zero migration version
+  Scenario Outline: Reject <case> migration version
     When I request to migrate with HTTP:
-      | database | postgres |
-      | version  |        0 |
+      | database | postgres  |
+      | version  | <version> |
     Then I should receive an invalid argument migration from HTTP
+
+    Examples:
+      | case      | version             |
+      | zero      |                   0 |
+      | oversized | 9223372036854775808 |
 
   @clean
   Scenario Outline: Migrate misconfigured databases
@@ -43,14 +48,15 @@ Feature: HTTP API
     Then I should receive an invalid migration from HTTP
 
     Examples:
-      | database       | version |
-      | missing_source |       1 |
-      | invalid_source |       1 |
-      | missing_url    |       1 |
-      | invalid_url    |       1 |
-      | invalid_db     |       1 |
-      | invalid_port   |       1 |
-      | postgres       |       3 |
+      | database             | version |
+      | missing_source       |       1 |
+      | invalid_source       |       1 |
+      | missing_url          |       1 |
+      | invalid_url          |       1 |
+      | invalid_db           |       1 |
+      | invalid_quoted_table |       1 |
+      | invalid_port         |       1 |
+      | postgres             |       3 |
 
   @reset
   Scenario: Migrate erroneous databases

--- a/test/lib/migrieren/v1/service_services_pb.rb
+++ b/test/lib/migrieren/v1/service_services_pb.rb
@@ -18,14 +18,15 @@ module Migrieren
 
         # Migrate migrates a configured database to the requested version.
         #
-        # Errors use InvalidArgument for zero versions, NotFound for unknown
-        # databases, Canceled/DeadlineExceeded for stopped requests, and Internal for
-        # configuration, source, database, or migration failures.
+        # Errors use InvalidArgument for versions outside the supported range,
+        # NotFound for unknown databases, Canceled/DeadlineExceeded for stopped
+        # requests, and Internal for configuration, source, database, or migration
+        # failures.
         #
         # gRPC failures after request validation include trailers when the request
         # reaches the transport migrator. This includes unknown database names and
-        # source/URL resolution failures; zero-version InvalidArgument responses do
-        # not use this trailer path.
+        # source/URL resolution failures; pre-migration validation InvalidArgument
+        # responses do not use this trailer path.
         # - migration-error: not_found, canceled, deadline_exceeded, invalid_config,
         #   invalid_migration, or unknown.
         # - migration-log-count: the number of migration log lines returned.

--- a/test/secrets/invalid_quoted_table
+++ b/test/secrets/invalid_quoted_table
@@ -1,0 +1,1 @@
+pgx5://test:test@localhost:5433/test?sslmode=disable&x-migrations-table-quoted=true


### PR DESCRIPTION
## What

- Reject migration versions outside the supported server range before the request reaches the transport migrator, and document that contract in README and protobuf comments.
- Reject `x-migrations-table-quoted=true` when no quoted table name is supplied, returning the normal invalid-migration path instead of allowing pgx driver setup to panic.
- Close the opened SQL handle when DB stats metric registration fails during pgx driver setup.
- Add gRPC and HTTP feature coverage plus a config fixture for oversized versions and invalid quoted-table configuration.

## Why

- Oversized `uint64` versions can overflow through upstream signed migration handling and run the wrong migration direction if accepted.
- Malformed quoted-table config should behave like other invalid database URLs instead of taking down the transport path.
- Telemetry registration failure should not leave an otherwise unusable database handle open.

## Testing

- `make specs` - passed; compiled the Go package surface, with the repo reporting 0 Go tests.
- `make feature=features/v1/transport/grpc/api.feature:38 features` - passed; covers oversized gRPC versions.
- `make feature=features/v1/transport/http/api.feature:38 features` - passed; covers oversized HTTP versions.
- `make feature=features/v1/transport/grpc/api.feature:98 features` - passed; covers invalid quoted-table config through gRPC.
- `make feature=features/v1/transport/http/api.feature:58 features` - passed; covers invalid quoted-table config through HTTP.
- `make lint` - passed.
- `make proto-generate` - passed.
- `make proto-stale` - passed after staging the intended generated outputs; an earlier pre-staging run reported the expected working-tree diff from this change.
- `make features` - passed; full Cucumber suite, 49 scenarios.
