### PR TITLE
feat(migrate): reject incomplete quoted table names

### DIFF
--- a/internal/migrate/pgx/pgx.go
+++ b/internal/migrate/pgx/pgx.go
@@ -7,6 +7,7 @@ import (
 	"strconv"
 
 	"github.com/alexfalkowski/go-service/v2/errors"
+	"github.com/alexfalkowski/go-service/v2/strings"
 	"github.com/alexfalkowski/go-service/v2/time"
 	"github.com/golang-migrate/migrate/v4/database"
 	"github.com/golang-migrate/migrate/v4/database/pgx/v5"
@@ -78,7 +79,7 @@ func parseMigrationsTableOptions(query url.Values) (string, bool, error) {
 	if err != nil {
 		return "", false, fmt.Errorf("unable to parse option x-migrations-table-quoted: %w", err)
 	}
-	if migrationsTableQuoted && (migrationsTable == "" || migrationsTable[0] != '"' || migrationsTable[len(migrationsTable)-1] != '"') {
+	if migrationsTableQuoted && invalidQuotedMigrationsTable(migrationsTable) {
 		return "", false, fmt.Errorf(
 			"%w: x-migrations-table must be quoted when x-migrations-table-quoted is enabled, current value is %q",
 			ErrInvalidMigrationsTable, migrationsTable,
@@ -86,6 +87,13 @@ func parseMigrationsTableOptions(query url.Values) (string, bool, error) {
 	}
 
 	return migrationsTable, migrationsTableQuoted, nil
+}
+
+func invalidQuotedMigrationsTable(migrationsTable string) bool {
+	return strings.IsEmpty(migrationsTable) ||
+		migrationsTable[0] != '"' ||
+		migrationsTable[len(migrationsTable)-1] != '"' ||
+		strings.IsEmpty(strings.Trim(migrationsTable, `"`))
 }
 
 func parseMultiStatementMaxSize(query url.Values) (int, error) {

--- a/test/.config/server.yml
+++ b/test/.config/server.yml
@@ -27,6 +27,9 @@ migrate:
     - name: invalid_quoted_table
       source: file:secrets/source
       url: file:secrets/invalid_quoted_table
+    - name: invalid_incomplete_quoted_table
+      source: file:secrets/source
+      url: file:secrets/invalid_incomplete_quoted_table
     - name: invalid_port
       source: file:secrets/source
       url: file:secrets/invalid_port

--- a/test/features/v1/transport/grpc/api.feature
+++ b/test/features/v1/transport/grpc/api.feature
@@ -75,10 +75,11 @@ Feature: gRPC API
       | stage | <stage> |
 
     Examples:
-      | database       | version | error             | logs    | stage  |
-      | missing_source |       1 | invalid_config    | empty   | source |
-      | missing_url    |       1 | invalid_config    | empty   | url    |
-      | postgres       |       3 | invalid_migration | present |        |
+      | database                         | version | error             | logs    | stage  |
+      | missing_source                   |       1 | invalid_config    | empty   | source |
+      | missing_url                      |       1 | invalid_config    | empty   | url    |
+      | invalid_incomplete_quoted_table  |       1 | invalid_config    | empty   |        |
+      | postgres                         |       3 | invalid_migration | present |        |
 
   @clean
   Scenario Outline: Migrate misconfigured databases
@@ -88,15 +89,16 @@ Feature: gRPC API
     Then I should receive an invalid migration from gRPC
 
     Examples:
-      | database             | version |
-      | missing_source       |       1 |
-      | invalid_source       |       1 |
-      | missing_url          |       1 |
-      | invalid_url          |       1 |
-      | invalid_db           |       1 |
-      | invalid_quoted_table |       1 |
-      | invalid_port         |       1 |
-      | postgres             |       3 |
+      | database                         | version |
+      | missing_source                   |       1 |
+      | invalid_source                   |       1 |
+      | missing_url                      |       1 |
+      | invalid_url                      |       1 |
+      | invalid_db                       |       1 |
+      | invalid_quoted_table             |       1 |
+      | invalid_incomplete_quoted_table  |       1 |
+      | invalid_port                     |       1 |
+      | postgres                         |       3 |
 
   @reset
   Scenario: Migrate erroneous databases

--- a/test/features/v1/transport/http/api.feature
+++ b/test/features/v1/transport/http/api.feature
@@ -48,15 +48,16 @@ Feature: HTTP API
     Then I should receive an invalid migration from HTTP
 
     Examples:
-      | database             | version |
-      | missing_source       |       1 |
-      | invalid_source       |       1 |
-      | missing_url          |       1 |
-      | invalid_url          |       1 |
-      | invalid_db           |       1 |
-      | invalid_quoted_table |       1 |
-      | invalid_port         |       1 |
-      | postgres             |       3 |
+      | database                         | version |
+      | missing_source                   |       1 |
+      | invalid_source                   |       1 |
+      | missing_url                      |       1 |
+      | invalid_url                      |       1 |
+      | invalid_db                       |       1 |
+      | invalid_quoted_table             |       1 |
+      | invalid_incomplete_quoted_table  |       1 |
+      | invalid_port                     |       1 |
+      | postgres                         |       3 |
 
   @reset
   Scenario: Migrate erroneous databases

--- a/test/secrets/invalid_incomplete_quoted_table
+++ b/test/secrets/invalid_incomplete_quoted_table
@@ -1,0 +1,1 @@
+pgx5://test:test@localhost:5433/test?sslmode=disable&x-migrations-table=%22&x-migrations-table-quoted=true


### PR DESCRIPTION
## What

- Reject quoted pgx table names that contain no table content after quote trimming, so malformed quoted-table config returns the normal invalid-config error path.
- Add an `invalid_incomplete_quoted_table` feature fixture and cover it through the HTTP and gRPC misconfiguration scenarios.
- Extend gRPC failure-diagnostics coverage to assert the incomplete quoted-table case reports `invalid_config` instead of falling through to recovery-only behavior.

## Why

- A quote-only `x-migrations-table` value could pass Migrieren's adapter validation and reach the upstream pgx driver path that expects at least one quoted identifier.
- Keeping this failure in Migrieren's validation path preserves stable error classification and diagnostic trailers for operators and clients.

## Testing

- `make features feature=features/v1/transport/http/api.feature` - passed
- `make features feature=features/v1/transport/grpc/api.feature` - passed
- `make specs` - passed; this repo currently reports 0 Go tests for that target.
- `make lint` - passed

AI-assisted-by: [Codex](https://openai.com/codex/)
