### PR TITLE
feat(transport): layer v1 contract over api migrator

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -349,7 +349,8 @@ A sample config used for dev/tests exists at `test/.config/server.yml`.
 ### API / transport
 
 - `api/migrieren/v1/service.proto`: gRPC contract.
-- `internal/api/migrate/`: transport-facing migrator (reads source/URL bytes using `go-service/v2/os.FS`).
+- `internal/api/migrate/`: API-facing migrator that resolves database names through config.
+- `internal/api/v1/migrate/`: versioned API contract shared by HTTP and gRPC transports.
 - `internal/api/v1/transport/grpc/`: gRPC server + handler implementation.
 - `internal/api/v1/transport/http/`: HTTP routing via `go-service/v2/net/http/rpc`.
 

--- a/README.md
+++ b/README.md
@@ -524,7 +524,8 @@ Key locations:
 - `internal/cmd/server.go`: registers the `server` command.
 - `internal/config/config.go`: top-level config composition.
 - `internal/migrate/`: core migration engine and driver wiring.
-- `internal/api/migrate/`: transport-facing adapter that resolves database names through config.
+- `internal/api/migrate/`: API-facing adapter that resolves database names through config.
+- `internal/api/v1/migrate/`: versioned API contract shared by HTTP and gRPC transports.
 - `internal/api/v1/transport/grpc/`: gRPC server implementation.
 - `internal/api/v1/transport/http/`: HTTP RPC route registration.
 - `internal/health/`: health registration and database-specific health checks.

--- a/internal/api/migrate/apply.go
+++ b/internal/api/migrate/apply.go
@@ -11,27 +11,16 @@ import (
 // The database is resolved from configuration by name. Its migration source and
 // database URL are read via the filesystem abstraction, then passed to the core
 // migrator.
-//
-// Returns the input context, or a derived context when migration setup or the
-// core migrator adds metadata, plus the resulting migration version and
-// migration logs. If the database name does not exist in the configuration,
-// this returns an error that wraps
-// `internal/migrate.ErrNotFound` (detectable via [IsNotFound]).
-//
-// Source and URL resolution failures return the underlying filesystem error and
-// a derived context containing a diagnostic stage. Staged failures are
-// classified as "invalid_config" for transport diagnostics. Failed migrations
-// may carry safe failure diagnostics on the returned error.
 func (s *Migrator) ApplyMigrations(ctx context.Context, db string) (context.Context, uint64, []string, error) {
-	ctx, source, url, err := s.sourceAndURL(ctx, db)
+	source, url, err := s.sourceAndURL(db)
 	if err != nil {
 		return ctx, 0, nil, err
 	}
 
 	ctx, version, logs, err := s.migrator.ApplyMigrations(ctx, bytes.String(source), bytes.String(url))
 	if err != nil {
-		err = diagnostics.Error(ctx, err, logs)
+		return ctx, version, logs, diagnostics.Error(err, logs)
 	}
 
-	return ctx, version, logs, err
+	return ctx, version, logs, nil
 }

--- a/internal/api/migrate/database.go
+++ b/internal/api/migrate/database.go
@@ -3,28 +3,24 @@ package migrate
 import (
 	"fmt"
 
-	"github.com/alexfalkowski/go-service/v2/context"
 	"github.com/alexfalkowski/migrieren/internal/diagnostics"
 )
 
-func (s *Migrator) sourceAndURL(ctx context.Context, db string) (context.Context, []byte, []byte, error) {
+func (s *Migrator) sourceAndURL(db string) ([]byte, []byte, error) {
 	d, err := s.config.Database(db)
 	if err != nil {
-		err = fmt.Errorf("%s: %w", db, err)
-		return ctx, nil, nil, diagnostics.Error(ctx, err, nil)
+		return nil, nil, diagnostics.Error(fmt.Errorf("%s: %w", db, err), nil)
 	}
 
 	source, err := d.GetSource(s.fs)
 	if err != nil {
-		ctx = diagnostics.WithStage(ctx, diagnostics.StageSource)
-		return ctx, nil, nil, diagnostics.Error(ctx, err, nil)
+		return nil, nil, diagnostics.InvalidConfig(err, diagnostics.StageSource)
 	}
 
 	url, err := d.GetURL(s.fs)
 	if err != nil {
-		ctx = diagnostics.WithStage(ctx, diagnostics.StageURL)
-		return ctx, nil, nil, diagnostics.Error(ctx, err, nil)
+		return nil, nil, diagnostics.InvalidConfig(err, diagnostics.StageURL)
 	}
 
-	return ctx, source, url, nil
+	return source, url, nil
 }

--- a/internal/api/migrate/doc.go
+++ b/internal/api/migrate/doc.go
@@ -1,9 +1,9 @@
-// Package migrate provides a transport-facing adapter around the core migration
+// Package migrate provides an API-facing adapter around the core migration
 // engine.
 //
-// This package is used by API/transport layers (for example gRPC or HTTP) to
-// execute migrations, inspect migration status, or list configured logical
-// database names based on the service configuration.
+// This package is used by versioned API layers to execute migrations, inspect
+// migration status, or list configured logical database names based on the
+// service configuration.
 //
 // # Responsibilities
 //
@@ -17,23 +17,7 @@
 //   - Listing configured logical database names without exposing source or URL
 //     values.
 //
-// The transport-facing API intentionally does not expose the underlying
-// source/URL resolution details to callers; callers typically provide only a
-// database name, plus a target version for migration requests.
-//
-// # Not found handling
-//
-// When a database name is not present in the configuration,
-// [Migrator.Migrate], [Migrator.ApplyMigrations], and [Migrator.Status] return
-// a wrapped error that includes the original sentinel error
-// [github.com/alexfalkowski/migrieren/internal/migrate.ErrNotFound]. Use [IsNotFound]
-// to test for this condition when mapping errors to transport status codes.
-//
-// # Observability
-//
-// Underlying migration and driver errors are handled by the core migrator and
-// are typically attached to request metadata for telemetry. Failed migration
-// requests also carry safe diagnostics on the returned error for transport
-// headers or trailers. This adapter focuses on configuration lookup,
-// secret/source resolution, and safe diagnostic classification.
+// The API-facing contract intentionally does not expose the underlying
+// source/URL resolution details to callers; callers provide only a database name,
+// plus a target version for migration requests.
 package migrate

--- a/internal/api/migrate/errors.go
+++ b/internal/api/migrate/errors.go
@@ -7,9 +7,6 @@ import (
 
 // IsNotFound reports whether err indicates that the requested database name was
 // not present in the configured database list.
-//
-// This is intended for transport layers to map the condition to an appropriate
-// status code (for example gRPC NotFound / HTTP 404).
 func IsNotFound(err error) bool {
 	return errors.Is(err, migrate.ErrNotFound)
 }

--- a/internal/api/migrate/migrate.go
+++ b/internal/api/migrate/migrate.go
@@ -11,30 +11,16 @@ import (
 // The database is resolved from configuration by name. Its migration source and
 // database URL are read via the filesystem abstraction, then passed to the core
 // migrator.
-//
-// This adapter does not perform public request validation such as rejecting a
-// zero version; transport callers that expose the migrieren.v1 API must enforce
-// that contract before calling Migrate.
-//
-// Returns the input context, or a derived context when migration setup or the
-// core migrator adds metadata, plus migration logs. If the database name does
-// not exist in the configuration, this returns an error that wraps
-// `internal/migrate.ErrNotFound` (detectable via [IsNotFound]).
-//
-// Source and URL resolution failures return the underlying filesystem error and
-// a derived context containing a diagnostic stage. Staged failures are
-// classified as "invalid_config" for transport diagnostics. Failed migrations
-// may carry safe failure diagnostics on the returned error.
 func (s *Migrator) Migrate(ctx context.Context, db string, version uint64) (context.Context, []string, error) {
-	ctx, source, url, err := s.sourceAndURL(ctx, db)
+	source, url, err := s.sourceAndURL(db)
 	if err != nil {
 		return ctx, nil, err
 	}
 
 	ctx, logs, err := s.migrator.Migrate(ctx, bytes.String(source), bytes.String(url), version)
 	if err != nil {
-		err = diagnostics.Error(ctx, err, logs)
+		return ctx, logs, diagnostics.Error(err, logs)
 	}
 
-	return ctx, logs, err
+	return ctx, logs, nil
 }

--- a/internal/api/migrate/migrator.go
+++ b/internal/api/migrate/migrator.go
@@ -5,26 +5,22 @@ import (
 	"github.com/alexfalkowski/migrieren/internal/migrate"
 )
 
-// NewMigrator constructs a transport-facing [Migrator].
+// NewMigrator constructs an API-facing [Migrator].
 //
 // Dependencies:
-//   - migrator: the core migrator that executes migrations given a source URL and
-//     database URL.
-//   - fs: a filesystem abstraction used to resolve `Database.Source` and
-//     `Database.URL` values (for example `file:...`).
-//   - cfg: the migration configuration containing the list of named databases.
+//   - migrator executes core migration operations against resolved source and
+//     database URLs.
+//   - fs resolves configured source and URL values.
+//   - cfg contains the configured logical database list.
 func NewMigrator(migrator *migrate.Migrator, fs *os.FS, cfg *migrate.Config) *Migrator {
 	return &Migrator{migrator: migrator, fs: fs, config: cfg}
 }
 
-// Migrator adapts the core migrator to a "database name + version" API that is
-// convenient for transport layers.
+// Migrator adapts the core migrator to a database-name API.
 //
-// The adapter:
-//   - looks up a database by name in the provided config,
-//   - reads its source and URL through the filesystem abstraction,
-//   - delegates migration execution or status inspection to the core migrator,
-//   - lists configured logical database names without exposing source or URL values.
+// It resolves configured source and URL values for a logical database name,
+// delegates work to the core migrator, and keeps configured secrets out of the
+// versioned API layer.
 type Migrator struct {
 	migrator *migrate.Migrator
 	config   *migrate.Config

--- a/internal/api/migrate/status.go
+++ b/internal/api/migrate/status.go
@@ -14,11 +14,6 @@ import (
 // The database is resolved from configuration by name. Only its database URL is
 // read via the filesystem abstraction; source resolution is not needed for this
 // status inspection path.
-//
-// If the database name does not exist in the configuration, this returns an
-// error that wraps `internal/migrate.ErrNotFound` (detectable via [IsNotFound]).
-// URL resolution failures return the underlying filesystem error and a derived
-// context containing a URL diagnostic stage.
 func (s *Migrator) Status(ctx context.Context, db string) (context.Context, *migrate.Status, error) {
 	d, err := s.config.Database(db)
 	if err != nil {
@@ -27,8 +22,7 @@ func (s *Migrator) Status(ctx context.Context, db string) (context.Context, *mig
 
 	url, err := d.GetURL(s.fs)
 	if err != nil {
-		ctx = diagnostics.WithStage(ctx, diagnostics.StageURL)
-		return ctx, nil, err
+		return ctx, nil, diagnostics.InvalidConfig(err, diagnostics.StageURL)
 	}
 
 	return s.migrator.Status(ctx, bytes.String(url))

--- a/internal/api/v1/migrate/apply.go
+++ b/internal/api/v1/migrate/apply.go
@@ -1,0 +1,29 @@
+package migrate
+
+import (
+	"github.com/alexfalkowski/go-service/v2/context"
+	"github.com/alexfalkowski/go-service/v2/meta"
+	"github.com/alexfalkowski/go-service/v2/strings"
+	v1 "github.com/alexfalkowski/migrieren/api/migrieren/v1"
+)
+
+// ApplyMigrations applies all pending up migrations for a configured database.
+func (s *Migrator) ApplyMigrations(ctx context.Context, req *v1.ApplyMigrationsRequest) (*v1.ApplyMigrationsResponse, error) {
+	db := req.GetDatabase()
+
+	ctx, version, logs, err := s.migrator.ApplyMigrations(ctx, db)
+	if err != nil {
+		return nil, err
+	}
+
+	resp := &v1.ApplyMigrationsResponse{
+		Meta: meta.CamelStrings(ctx, strings.Empty),
+		Migration: &v1.Migration{
+			Database: db,
+			Logs:     logs,
+			Version:  version,
+		},
+	}
+
+	return resp, nil
+}

--- a/internal/api/v1/migrate/doc.go
+++ b/internal/api/v1/migrate/doc.go
@@ -1,0 +1,12 @@
+// Package migrate implements the migrieren.v1 migration contract shared by
+// transports.
+//
+// The package accepts generated v1 request messages and returns generated v1
+// response messages. It owns versioned API response construction, public request
+// validation, configured database lookup, source/URL resolution, and delegation
+// to the core migration engine.
+//
+// Transport packages remain responsible for registration, safe status-code
+// mapping, and exposing diagnostics as the correct transport metadata
+// mechanism, such as gRPC trailers or HTTP response headers.
+package migrate

--- a/internal/api/v1/migrate/errors.go
+++ b/internal/api/v1/migrate/errors.go
@@ -1,0 +1,32 @@
+package migrate
+
+import (
+	"github.com/alexfalkowski/go-service/v2/errors"
+	"github.com/alexfalkowski/migrieren/internal/api/migrate"
+)
+
+// ErrInvalidVersion is returned when a v1 migrate request uses a version outside
+// the public API range.
+var ErrInvalidVersion = errors.New("version must be between 1 and math.MaxInt")
+
+// IsInvalidVersion reports whether err indicates an unsupported target version.
+func IsInvalidVersion(err error) bool {
+	return errors.Is(err, ErrInvalidVersion)
+}
+
+// IsNotFound reports whether err indicates that the requested database name was
+// not present in the configured database list.
+func IsNotFound(err error) bool {
+	return migrate.IsNotFound(err)
+}
+
+// IsCanceled reports whether err indicates the caller canceled migration work.
+func IsCanceled(err error) bool {
+	return migrate.IsCanceled(err)
+}
+
+// IsDeadlineExceeded reports whether err indicates migration work exceeded the
+// request deadline.
+func IsDeadlineExceeded(err error) bool {
+	return migrate.IsDeadlineExceeded(err)
+}

--- a/internal/api/v1/migrate/list.go
+++ b/internal/api/v1/migrate/list.go
@@ -1,0 +1,23 @@
+package migrate
+
+import (
+	"github.com/alexfalkowski/go-service/v2/context"
+	"github.com/alexfalkowski/go-service/v2/meta"
+	"github.com/alexfalkowski/go-service/v2/strings"
+	v1 "github.com/alexfalkowski/migrieren/api/migrieren/v1"
+)
+
+// ListDatabases reports configured logical database names in config order.
+func (s *Migrator) ListDatabases(ctx context.Context, _ *v1.ListDatabasesRequest) (*v1.ListDatabasesResponse, error) {
+	databases := s.migrator.Databases()
+	resp := &v1.ListDatabasesResponse{
+		Meta:      meta.CamelStrings(ctx, strings.Empty),
+		Databases: make([]*v1.Database, 0, len(databases)),
+	}
+
+	for _, name := range databases {
+		resp.Databases = append(resp.Databases, &v1.Database{Name: name})
+	}
+
+	return resp, nil
+}

--- a/internal/api/v1/migrate/migrate.go
+++ b/internal/api/v1/migrate/migrate.go
@@ -1,0 +1,36 @@
+package migrate
+
+import (
+	"math"
+
+	"github.com/alexfalkowski/go-service/v2/context"
+	"github.com/alexfalkowski/go-service/v2/meta"
+	"github.com/alexfalkowski/go-service/v2/strings"
+	v1 "github.com/alexfalkowski/migrieren/api/migrieren/v1"
+)
+
+// Migrate migrates a configured database to the requested version.
+func (s *Migrator) Migrate(ctx context.Context, req *v1.MigrateRequest) (*v1.MigrateResponse, error) {
+	db := req.GetDatabase()
+	ver := req.GetVersion()
+
+	if ver == 0 || ver > math.MaxInt {
+		return nil, ErrInvalidVersion
+	}
+
+	ctx, logs, err := s.migrator.Migrate(ctx, db, ver)
+	if err != nil {
+		return nil, err
+	}
+
+	resp := &v1.MigrateResponse{
+		Migration: &v1.Migration{
+			Database: db,
+			Version:  ver,
+			Logs:     logs,
+		},
+		Meta: meta.CamelStrings(ctx, strings.Empty),
+	}
+
+	return resp, nil
+}

--- a/internal/api/v1/migrate/migrator.go
+++ b/internal/api/v1/migrate/migrator.go
@@ -1,0 +1,20 @@
+package migrate
+
+import "github.com/alexfalkowski/migrieren/internal/api/migrate"
+
+// NewMigrator constructs a v1 migration service.
+//
+// Dependencies:
+//   - migrator resolves configured database names and executes migration work.
+func NewMigrator(migrator *migrate.Migrator) *Migrator {
+	return &Migrator{migrator: migrator}
+}
+
+// Migrator implements the transport-neutral migrieren.v1 migration contract.
+//
+// It accepts generated v1 request messages, delegates database-name migration
+// work to the API migrator, and returns generated v1 response messages for
+// transport adapters to expose.
+type Migrator struct {
+	migrator *migrate.Migrator
+}

--- a/internal/api/v1/migrate/module.go
+++ b/internal/api/v1/migrate/module.go
@@ -2,10 +2,10 @@ package migrate
 
 import (
 	"github.com/alexfalkowski/go-service/v2/di"
-	"github.com/alexfalkowski/migrieren/internal/migrate"
+	"github.com/alexfalkowski/migrieren/internal/api/migrate"
 )
 
-// Module wires the API-facing migrator into the DI container.
+// Module wires the v1 migration service into the DI container.
 var Module = di.Module(
 	migrate.Module,
 	di.Constructor(NewMigrator),

--- a/internal/api/v1/migrate/status.go
+++ b/internal/api/v1/migrate/status.go
@@ -1,0 +1,43 @@
+package migrate
+
+import (
+	"github.com/alexfalkowski/go-service/v2/context"
+	"github.com/alexfalkowski/go-service/v2/meta"
+	"github.com/alexfalkowski/go-service/v2/strings"
+	v1 "github.com/alexfalkowski/migrieren/api/migrieren/v1"
+	"github.com/alexfalkowski/migrieren/internal/migrate"
+)
+
+// Status reports the current migration version state for a configured database.
+func (s *Migrator) Status(ctx context.Context, req *v1.StatusRequest) (*v1.StatusResponse, error) {
+	db := req.GetDatabase()
+
+	ctx, state, err := s.migrator.Status(ctx, db)
+	if err != nil {
+		return nil, err
+	}
+
+	resp := &v1.StatusResponse{
+		Meta: meta.CamelStrings(ctx, strings.Empty),
+		Status: &v1.MigrationStatus{
+			Database: db,
+			Version:  state.Version,
+			State:    migrationState(state.State),
+		},
+	}
+
+	return resp, nil
+}
+
+func migrationState(state migrate.StatusState) v1.MigrationState {
+	switch state {
+	case migrate.StatusStateUnapplied:
+		return v1.MigrationState_MIGRATION_STATE_UNAPPLIED
+	case migrate.StatusStateClean:
+		return v1.MigrationState_MIGRATION_STATE_CLEAN
+	case migrate.StatusStateDirty:
+		return v1.MigrationState_MIGRATION_STATE_DIRTY
+	default:
+		return v1.MigrationState_MIGRATION_STATE_UNSPECIFIED
+	}
+}

--- a/internal/api/v1/module.go
+++ b/internal/api/v1/module.go
@@ -2,15 +2,13 @@ package v1
 
 import (
 	"github.com/alexfalkowski/go-service/v2/di"
-	api "github.com/alexfalkowski/migrieren/internal/api/migrate"
+	"github.com/alexfalkowski/migrieren/internal/api/v1/migrate"
 	"github.com/alexfalkowski/migrieren/internal/api/v1/transport/grpc"
 	"github.com/alexfalkowski/migrieren/internal/api/v1/transport/http"
-	"github.com/alexfalkowski/migrieren/internal/migrate"
 )
 
 // Module wires the v1 API transports and handlers into the DI container.
 var Module = di.Module(
-	api.Module,
 	migrate.Module,
 	di.Constructor(grpc.NewServer),
 	di.Register(grpc.Register),

--- a/internal/api/v1/transport/grpc/apply.go
+++ b/internal/api/v1/transport/grpc/apply.go
@@ -2,25 +2,17 @@ package grpc
 
 import (
 	"github.com/alexfalkowski/go-service/v2/context"
-	"github.com/alexfalkowski/go-service/v2/meta"
-	"github.com/alexfalkowski/go-service/v2/strings"
 	v1 "github.com/alexfalkowski/migrieren/api/migrieren/v1"
 	"github.com/alexfalkowski/migrieren/internal/diagnostics"
 )
 
 // ApplyMigrations applies all pending up migrations for a configured database.
 func (s *Server) ApplyMigrations(ctx context.Context, req *v1.ApplyMigrationsRequest) (*v1.ApplyMigrationsResponse, error) {
-	db := req.GetDatabase()
-	resp := &v1.ApplyMigrationsResponse{
-		Migration: &v1.Migration{Database: db},
+	resp, err := s.migrator.ApplyMigrations(ctx, req)
+	if err != nil {
+		setFailureTrailer(ctx, diagnostics.FromError(err))
+		return nil, s.error(err)
 	}
 
-	ctx, version, logs, err := s.migrator.ApplyMigrations(ctx, db)
-	setFailureTrailer(ctx, diagnostics.FromError(err))
-
-	resp.Meta = meta.CamelStrings(ctx, strings.Empty)
-	resp.Migration.Version = version
-	resp.Migration.Logs = logs
-
-	return resp, s.error(err)
+	return resp, nil
 }

--- a/internal/api/v1/transport/grpc/doc.go
+++ b/internal/api/v1/transport/grpc/doc.go
@@ -1,7 +1,7 @@
 // Package grpc implements the migrieren.v1 gRPC transport.
 //
 // It registers the generated service server, delegates migration and status
-// work to the transport-facing migrator, maps domain errors to gRPC status
+// work to the versioned API migrator, maps domain errors to gRPC status
 // codes, and adds safe failure diagnostics as trailers for post-validation
 // migration failures.
 package grpc

--- a/internal/api/v1/transport/grpc/grpc.go
+++ b/internal/api/v1/transport/grpc/grpc.go
@@ -1,11 +1,14 @@
 package grpc
 
 import (
+	"github.com/alexfalkowski/go-service/v2/context"
 	"github.com/alexfalkowski/go-service/v2/net/grpc"
 	"github.com/alexfalkowski/go-service/v2/net/grpc/codes"
+	"github.com/alexfalkowski/go-service/v2/net/grpc/meta"
 	"github.com/alexfalkowski/go-service/v2/net/grpc/status"
 	v1 "github.com/alexfalkowski/migrieren/api/migrieren/v1"
-	"github.com/alexfalkowski/migrieren/internal/api/migrate"
+	"github.com/alexfalkowski/migrieren/internal/api/v1/migrate"
+	"github.com/alexfalkowski/migrieren/internal/diagnostics"
 )
 
 // Register registers server as the migrieren.v1 gRPC service implementation.
@@ -20,7 +23,7 @@ func NewServer(service *migrate.Migrator) *Server {
 
 // Server implements the migrieren.v1 gRPC service.
 //
-// It delegates migration work to the transport-facing migrator and maps domain
+// It delegates migration work to the versioned API migrator and maps domain
 // errors to gRPC status codes.
 type Server struct {
 	v1.UnimplementedServiceServer
@@ -28,8 +31,8 @@ type Server struct {
 }
 
 func (s *Server) error(err error) error {
-	if err == nil {
-		return nil
+	if migrate.IsInvalidVersion(err) {
+		return status.Error(codes.InvalidArgument, err.Error())
 	}
 
 	if migrate.IsNotFound(err) {
@@ -45,4 +48,8 @@ func (s *Server) error(err error) error {
 	}
 
 	return status.SafeError(codes.Internal, err)
+}
+
+func setFailureTrailer(ctx context.Context, values diagnostics.Values) {
+	_ = grpc.SetTrailer(ctx, meta.New(values.Map()))
 }

--- a/internal/api/v1/transport/grpc/list.go
+++ b/internal/api/v1/transport/grpc/list.go
@@ -2,22 +2,10 @@ package grpc
 
 import (
 	"github.com/alexfalkowski/go-service/v2/context"
-	"github.com/alexfalkowski/go-service/v2/meta"
-	"github.com/alexfalkowski/go-service/v2/strings"
 	v1 "github.com/alexfalkowski/migrieren/api/migrieren/v1"
 )
 
 // ListDatabases reports configured logical database names.
-func (s *Server) ListDatabases(ctx context.Context, _ *v1.ListDatabasesRequest) (*v1.ListDatabasesResponse, error) {
-	databases := s.migrator.Databases()
-	resp := &v1.ListDatabasesResponse{
-		Meta:      meta.CamelStrings(ctx, strings.Empty),
-		Databases: make([]*v1.Database, 0, len(databases)),
-	}
-
-	for _, name := range databases {
-		resp.Databases = append(resp.Databases, &v1.Database{Name: name})
-	}
-
-	return resp, nil
+func (s *Server) ListDatabases(ctx context.Context, req *v1.ListDatabasesRequest) (*v1.ListDatabasesResponse, error) {
+	return s.migrator.ListDatabases(ctx, req)
 }

--- a/internal/api/v1/transport/grpc/migrate.go
+++ b/internal/api/v1/transport/grpc/migrate.go
@@ -1,15 +1,7 @@
 package grpc
 
 import (
-	"math"
-
 	"github.com/alexfalkowski/go-service/v2/context"
-	"github.com/alexfalkowski/go-service/v2/meta"
-	"github.com/alexfalkowski/go-service/v2/net/grpc"
-	"github.com/alexfalkowski/go-service/v2/net/grpc/codes"
-	grpcmeta "github.com/alexfalkowski/go-service/v2/net/grpc/meta"
-	"github.com/alexfalkowski/go-service/v2/net/grpc/status"
-	"github.com/alexfalkowski/go-service/v2/strings"
 	v1 "github.com/alexfalkowski/migrieren/api/migrieren/v1"
 	"github.com/alexfalkowski/migrieren/internal/diagnostics"
 )
@@ -17,42 +9,11 @@ import (
 // Migrate executes the requested migration and returns response metadata and
 // collected migration logs.
 func (s *Server) Migrate(ctx context.Context, req *v1.MigrateRequest) (*v1.MigrateResponse, error) {
-	db := req.GetDatabase()
-	ver := req.GetVersion()
-	resp := &v1.MigrateResponse{
-		Migration: &v1.Migration{
-			Database: db,
-			Version:  ver,
-		},
+	resp, err := s.migrator.Migrate(ctx, req)
+	if err != nil {
+		setFailureTrailer(ctx, diagnostics.FromError(err))
+		return nil, s.error(err)
 	}
 
-	if ver == 0 || ver > math.MaxInt {
-		return resp, status.Error(codes.InvalidArgument, "version must be between 1 and math.MaxInt")
-	}
-
-	ctx, logs, err := s.migrator.Migrate(ctx, db, ver)
-	setFailureTrailer(ctx, diagnostics.FromError(err))
-
-	resp.Meta = meta.CamelStrings(ctx, strings.Empty)
-	resp.Migration.Logs = logs
-
-	return resp, s.error(err)
-}
-
-func setFailureTrailer(ctx context.Context, values diagnostics.Values) {
-	pairs := failureDiagnosticPairs(values)
-	if len(pairs) == 0 {
-		return
-	}
-
-	_ = grpc.SetTrailer(ctx, grpcmeta.Pairs(pairs...))
-}
-
-func failureDiagnosticPairs(values diagnostics.Values) []string {
-	pairs := make([]string, 0, len(values)*2)
-	for key, value := range values {
-		pairs = append(pairs, key, value)
-	}
-
-	return pairs
+	return resp, nil
 }

--- a/internal/api/v1/transport/grpc/status.go
+++ b/internal/api/v1/transport/grpc/status.go
@@ -2,39 +2,15 @@ package grpc
 
 import (
 	"github.com/alexfalkowski/go-service/v2/context"
-	"github.com/alexfalkowski/go-service/v2/meta"
-	"github.com/alexfalkowski/go-service/v2/strings"
 	v1 "github.com/alexfalkowski/migrieren/api/migrieren/v1"
-	"github.com/alexfalkowski/migrieren/internal/migrate"
 )
 
 // Status reports the current migration version state for a configured database.
 func (s *Server) Status(ctx context.Context, req *v1.StatusRequest) (*v1.StatusResponse, error) {
-	db := req.GetDatabase()
-	resp := &v1.StatusResponse{
-		Status: &v1.MigrationStatus{Database: db},
+	resp, err := s.migrator.Status(ctx, req)
+	if err != nil {
+		return nil, s.error(err)
 	}
 
-	ctx, state, err := s.migrator.Status(ctx, db)
-	resp.Meta = meta.CamelStrings(ctx, strings.Empty)
-
-	if state != nil {
-		resp.Status.Version = state.Version
-		resp.Status.State = migrationState(state.State)
-	}
-
-	return resp, s.error(err)
-}
-
-func migrationState(state migrate.StatusState) v1.MigrationState {
-	switch state {
-	case migrate.StatusStateUnapplied:
-		return v1.MigrationState_MIGRATION_STATE_UNAPPLIED
-	case migrate.StatusStateClean:
-		return v1.MigrationState_MIGRATION_STATE_CLEAN
-	case migrate.StatusStateDirty:
-		return v1.MigrationState_MIGRATION_STATE_DIRTY
-	default:
-		return v1.MigrationState_MIGRATION_STATE_UNSPECIFIED
-	}
+	return resp, nil
 }

--- a/internal/api/v1/transport/http/apply.go
+++ b/internal/api/v1/transport/http/apply.go
@@ -3,15 +3,18 @@ package http
 import (
 	"github.com/alexfalkowski/go-service/v2/context"
 	v1 "github.com/alexfalkowski/migrieren/api/migrieren/v1"
-	"github.com/alexfalkowski/migrieren/internal/api/v1/transport/grpc"
+	"github.com/alexfalkowski/migrieren/internal/api/v1/migrate"
 	"github.com/alexfalkowski/migrieren/internal/diagnostics"
 )
 
-func apply(server *grpc.Server) func(context.Context, *v1.ApplyMigrationsRequest) (*v1.ApplyMigrationsResponse, error) {
+func applyMigrations(migrator *migrate.Migrator) func(context.Context, *v1.ApplyMigrationsRequest) (*v1.ApplyMigrationsResponse, error) {
 	return func(ctx context.Context, req *v1.ApplyMigrationsRequest) (*v1.ApplyMigrationsResponse, error) {
-		resp, err := server.ApplyMigrations(ctx, req)
-		setFailureHeaders(ctx, diagnostics.FromError(err))
+		resp, err := migrator.ApplyMigrations(ctx, req)
+		if err != nil {
+			setFailureHeaders(ctx, diagnostics.FromError(err))
+			return nil, responseError(err)
+		}
 
-		return resp, err
+		return resp, nil
 	}
 }

--- a/internal/api/v1/transport/http/doc.go
+++ b/internal/api/v1/transport/http/doc.go
@@ -1,6 +1,6 @@
 // Package http registers the HTTP RPC facade for the migrieren.v1 API.
 //
 // The shared HTTP RPC runtime exposes the generated gRPC service methods at the
-// repository-documented HTTP routes while keeping request handling delegated to
-// the gRPC transport implementation.
+// repository-documented HTTP routes while delegating migration behavior to the
+// versioned API migrator.
 package http

--- a/internal/api/v1/transport/http/error.go
+++ b/internal/api/v1/transport/http/error.go
@@ -1,0 +1,27 @@
+package http
+
+import (
+	"github.com/alexfalkowski/go-service/v2/net/http"
+	"github.com/alexfalkowski/go-service/v2/net/http/status"
+	"github.com/alexfalkowski/migrieren/internal/api/v1/migrate"
+)
+
+func responseError(err error) error {
+	if migrate.IsInvalidVersion(err) {
+		return status.Error(http.StatusBadRequest, err.Error())
+	}
+
+	if migrate.IsNotFound(err) {
+		return status.SafeError(http.StatusNotFound, err)
+	}
+
+	if migrate.IsCanceled(err) {
+		return status.SafeError(http.StatusClientClosedRequest, err)
+	}
+
+	if migrate.IsDeadlineExceeded(err) {
+		return status.SafeError(http.StatusGatewayTimeout, err)
+	}
+
+	return status.SafeError(http.StatusInternalServerError, err)
+}

--- a/internal/api/v1/transport/http/http.go
+++ b/internal/api/v1/transport/http/http.go
@@ -5,16 +5,16 @@ import (
 	"github.com/alexfalkowski/go-service/v2/net/http/meta"
 	"github.com/alexfalkowski/go-service/v2/net/http/rpc"
 	v1 "github.com/alexfalkowski/migrieren/api/migrieren/v1"
-	"github.com/alexfalkowski/migrieren/internal/api/v1/transport/grpc"
+	"github.com/alexfalkowski/migrieren/internal/api/v1/migrate"
 	"github.com/alexfalkowski/migrieren/internal/diagnostics"
 )
 
-// Register exposes the gRPC service methods through the HTTP RPC facade.
-func Register(server *grpc.Server) {
-	rpc.Route(v1.Service_Migrate_FullMethodName, migrate(server))
-	rpc.Route(v1.Service_ApplyMigrations_FullMethodName, apply(server))
-	rpc.Route(v1.Service_Status_FullMethodName, server.Status)
-	rpc.Route(v1.Service_ListDatabases_FullMethodName, server.ListDatabases)
+// Register exposes the v1 service methods through the HTTP RPC facade.
+func Register(migrator *migrate.Migrator) {
+	rpc.Route(v1.Service_Migrate_FullMethodName, migrateDatabase(migrator))
+	rpc.Route(v1.Service_ApplyMigrations_FullMethodName, applyMigrations(migrator))
+	rpc.Route(v1.Service_Status_FullMethodName, getStatus(migrator))
+	rpc.Route(v1.Service_ListDatabases_FullMethodName, migrator.ListDatabases)
 }
 
 func setFailureHeaders(ctx context.Context, values diagnostics.Values) {

--- a/internal/api/v1/transport/http/migrate.go
+++ b/internal/api/v1/transport/http/migrate.go
@@ -3,15 +3,18 @@ package http
 import (
 	"github.com/alexfalkowski/go-service/v2/context"
 	v1 "github.com/alexfalkowski/migrieren/api/migrieren/v1"
-	"github.com/alexfalkowski/migrieren/internal/api/v1/transport/grpc"
+	"github.com/alexfalkowski/migrieren/internal/api/v1/migrate"
 	"github.com/alexfalkowski/migrieren/internal/diagnostics"
 )
 
-func migrate(server *grpc.Server) func(context.Context, *v1.MigrateRequest) (*v1.MigrateResponse, error) {
+func migrateDatabase(migrator *migrate.Migrator) func(context.Context, *v1.MigrateRequest) (*v1.MigrateResponse, error) {
 	return func(ctx context.Context, req *v1.MigrateRequest) (*v1.MigrateResponse, error) {
-		resp, err := server.Migrate(ctx, req)
-		setFailureHeaders(ctx, diagnostics.FromError(err))
+		resp, err := migrator.Migrate(ctx, req)
+		if err != nil {
+			setFailureHeaders(ctx, diagnostics.FromError(err))
+			return nil, responseError(err)
+		}
 
-		return resp, err
+		return resp, nil
 	}
 }

--- a/internal/api/v1/transport/http/status.go
+++ b/internal/api/v1/transport/http/status.go
@@ -1,0 +1,18 @@
+package http
+
+import (
+	"github.com/alexfalkowski/go-service/v2/context"
+	v1 "github.com/alexfalkowski/migrieren/api/migrieren/v1"
+	"github.com/alexfalkowski/migrieren/internal/api/v1/migrate"
+)
+
+func getStatus(migrator *migrate.Migrator) func(context.Context, *v1.StatusRequest) (*v1.StatusResponse, error) {
+	return func(ctx context.Context, req *v1.StatusRequest) (*v1.StatusResponse, error) {
+		resp, err := migrator.Status(ctx, req)
+		if err != nil {
+			return nil, responseError(err)
+		}
+
+		return resp, nil
+	}
+}

--- a/internal/diagnostics/diagnostics.go
+++ b/internal/diagnostics/diagnostics.go
@@ -4,53 +4,48 @@ import (
 	"maps"
 	"strconv"
 
-	"github.com/alexfalkowski/go-service/v2/context"
 	"github.com/alexfalkowski/go-service/v2/errors"
-	"github.com/alexfalkowski/go-service/v2/meta"
 	"github.com/alexfalkowski/migrieren/internal/migrate"
 )
 
-// Values contains safe diagnostic key/value pairs attached to an error.
-type Values map[string]string
+const invalidConfig = "invalid_config"
 
-const (
-	stageKey = "migrateErrorStage"
+// StageSource identifies failures while resolving a migration source.
+const StageSource = "source"
 
-	// StageSource identifies failures while resolving a migration source.
-	StageSource = "source"
-
-	// StageURL identifies failures while resolving a database URL.
-	StageURL = "url"
-)
-
-// WithStage stores the migration diagnostic stage on ctx.
-func WithStage(ctx context.Context, stage string) context.Context {
-	return meta.WithAttributes(ctx, meta.NewPair(stageKey, meta.String(stage)))
-}
+// StageURL identifies failures while resolving a database URL.
+const StageURL = "url"
 
 // Error wraps err with safe migration diagnostic values.
 //
 // The returned error unwraps to err, so errors.Is and errors.As continue to
-// match the original cause. Passing nil returns nil.
-func Error(ctx context.Context, err error, logs []string) error {
-	if err == nil {
-		return nil
+// match the original cause.
+func Error(err error, logs []string) error {
+	return &diagnosticError{
+		err:    err,
+		values: newValues(err, logs),
+	}
+}
+
+// InvalidConfig wraps err with diagnostics for a migration configuration
+// resolution failure.
+func InvalidConfig(err error, stage string) error {
+	values := newValues(err, nil)
+	values["migration-error"] = invalidConfig
+	if stage != "" {
+		values["migration-stage"] = stage
 	}
 
 	return &diagnosticError{
 		err:    err,
-		values: newValues(ctx, err, logs),
+		values: values,
 	}
 }
 
-func newValues(ctx context.Context, err error, logs []string) Values {
+func newValues(err error, logs []string) Values {
 	values := Values{
-		"migration-error":     failureKind(ctx, err),
+		"migration-error":     failureKind(err),
 		"migration-log-count": strconv.Itoa(len(logs)),
-	}
-
-	if stage := meta.Attribute(ctx, stageKey); !stage.IsEmpty() {
-		values["migration-stage"] = stage.String()
 	}
 
 	if len(logs) > 0 {
@@ -60,7 +55,7 @@ func newValues(ctx context.Context, err error, logs []string) Values {
 	return values
 }
 
-func failureKind(ctx context.Context, err error) string {
+func failureKind(err error) string {
 	switch {
 	case errors.Is(err, migrate.ErrNotFound):
 		return "not_found"
@@ -68,8 +63,8 @@ func failureKind(ctx context.Context, err error) string {
 		return "canceled"
 	case errors.Is(err, migrate.ErrMigrationDeadlineExceeded):
 		return "deadline_exceeded"
-	case !meta.Attribute(ctx, stageKey).IsEmpty(), errors.Is(err, migrate.ErrInvalidConfig):
-		return "invalid_config"
+	case errors.Is(err, migrate.ErrInvalidConfig):
+		return invalidConfig
 	case errors.Is(err, migrate.ErrInvalidMigration):
 		return "invalid_migration"
 	default:
@@ -88,6 +83,21 @@ func FromError(err error) Values {
 	return Values{}
 }
 
+// Values contains safe diagnostic key/value pairs attached to an error.
+type Values map[string]string
+
+// Map returns a copy of v as a plain string map.
+func (v Values) Map() map[string]string {
+	values := make(map[string]string, len(v))
+	maps.Copy(values, v)
+
+	return values
+}
+
+func (v Values) copy() Values {
+	return Values(v.Map())
+}
+
 type diagnosticError struct {
 	err    error
 	values Values
@@ -99,11 +109,4 @@ func (d *diagnosticError) Error() string {
 
 func (d *diagnosticError) Unwrap() error {
 	return d.err
-}
-
-func (v Values) copy() Values {
-	values := make(Values, len(v))
-	maps.Copy(values, v)
-
-	return values
 }


### PR DESCRIPTION
## What

- Keep `internal/api/migrate` as the API-facing migrator that resolves configured database names, sources, and URLs.
- Add `internal/api/v1/migrate` as the v1 protobuf contract layer over that migrator.
- Have HTTP and gRPC call the v1 migrator independently while keeping protocol-specific status mapping and diagnostics metadata in each adapter.

## Why

- Removes the HTTP facade dependency on the gRPC server without collapsing config/source resolution into the versioned API layer.
- Preserves a clean boundary between database-name migration behavior, v1 request/response construction, and protocol-specific headers/trailers.

## Testing

- `make specs` - passed.
- `make lint` - passed.
- `make features` - passed; 78 scenarios and 177 steps.
