### PR TITLE
feat(http): add transport server adapter

### DIFF
--- a/internal/api/v1/module.go
+++ b/internal/api/v1/module.go
@@ -11,6 +11,7 @@ import (
 var Module = di.Module(
 	migrate.Module,
 	di.Constructor(grpc.NewServer),
+	di.Constructor(http.NewServer),
 	di.Register(grpc.Register),
 	di.Register(http.Register),
 )

--- a/internal/api/v1/transport/http/apply.go
+++ b/internal/api/v1/transport/http/apply.go
@@ -3,18 +3,16 @@ package http
 import (
 	"github.com/alexfalkowski/go-service/v2/context"
 	v1 "github.com/alexfalkowski/migrieren/api/migrieren/v1"
-	"github.com/alexfalkowski/migrieren/internal/api/v1/migrate"
 	"github.com/alexfalkowski/migrieren/internal/diagnostics"
 )
 
-func applyMigrations(migrator *migrate.Migrator) func(context.Context, *v1.ApplyMigrationsRequest) (*v1.ApplyMigrationsResponse, error) {
-	return func(ctx context.Context, req *v1.ApplyMigrationsRequest) (*v1.ApplyMigrationsResponse, error) {
-		resp, err := migrator.ApplyMigrations(ctx, req)
-		if err != nil {
-			setFailureHeaders(ctx, diagnostics.FromError(err))
-			return nil, responseError(err)
-		}
-
-		return resp, nil
+// ApplyMigrations applies all pending up migrations for a configured database.
+func (s *Server) ApplyMigrations(ctx context.Context, req *v1.ApplyMigrationsRequest) (*v1.ApplyMigrationsResponse, error) {
+	resp, err := s.migrator.ApplyMigrations(ctx, req)
+	if err != nil {
+		setFailureHeaders(ctx, diagnostics.FromError(err))
+		return nil, s.error(err)
 	}
+
+	return resp, nil
 }

--- a/internal/api/v1/transport/http/error.go
+++ b/internal/api/v1/transport/http/error.go
@@ -6,7 +6,7 @@ import (
 	"github.com/alexfalkowski/migrieren/internal/api/v1/migrate"
 )
 
-func responseError(err error) error {
+func (s *Server) error(err error) error {
 	if migrate.IsInvalidVersion(err) {
 		return status.Error(http.StatusBadRequest, err.Error())
 	}

--- a/internal/api/v1/transport/http/http.go
+++ b/internal/api/v1/transport/http/http.go
@@ -10,11 +10,24 @@ import (
 )
 
 // Register exposes the v1 service methods through the HTTP RPC facade.
-func Register(migrator *migrate.Migrator) {
-	rpc.Route(v1.Service_Migrate_FullMethodName, migrateDatabase(migrator))
-	rpc.Route(v1.Service_ApplyMigrations_FullMethodName, applyMigrations(migrator))
-	rpc.Route(v1.Service_Status_FullMethodName, getStatus(migrator))
-	rpc.Route(v1.Service_ListDatabases_FullMethodName, migrator.ListDatabases)
+func Register(server *Server) {
+	rpc.Route(v1.Service_Migrate_FullMethodName, server.Migrate)
+	rpc.Route(v1.Service_ApplyMigrations_FullMethodName, server.ApplyMigrations)
+	rpc.Route(v1.Service_Status_FullMethodName, server.Status)
+	rpc.Route(v1.Service_ListDatabases_FullMethodName, server.ListDatabases)
+}
+
+// NewServer constructs an HTTP RPC transport adapter around service.
+func NewServer(service *migrate.Migrator) *Server {
+	return &Server{migrator: service}
+}
+
+// Server implements the migrieren.v1 HTTP RPC facade.
+//
+// It delegates migration work to the versioned API migrator and maps domain
+// errors to HTTP response errors.
+type Server struct {
+	migrator *migrate.Migrator
 }
 
 func setFailureHeaders(ctx context.Context, values diagnostics.Values) {

--- a/internal/api/v1/transport/http/list.go
+++ b/internal/api/v1/transport/http/list.go
@@ -1,0 +1,11 @@
+package http
+
+import (
+	"github.com/alexfalkowski/go-service/v2/context"
+	v1 "github.com/alexfalkowski/migrieren/api/migrieren/v1"
+)
+
+// ListDatabases reports configured logical database names.
+func (s *Server) ListDatabases(ctx context.Context, req *v1.ListDatabasesRequest) (*v1.ListDatabasesResponse, error) {
+	return s.migrator.ListDatabases(ctx, req)
+}

--- a/internal/api/v1/transport/http/migrate.go
+++ b/internal/api/v1/transport/http/migrate.go
@@ -3,18 +3,17 @@ package http
 import (
 	"github.com/alexfalkowski/go-service/v2/context"
 	v1 "github.com/alexfalkowski/migrieren/api/migrieren/v1"
-	"github.com/alexfalkowski/migrieren/internal/api/v1/migrate"
 	"github.com/alexfalkowski/migrieren/internal/diagnostics"
 )
 
-func migrateDatabase(migrator *migrate.Migrator) func(context.Context, *v1.MigrateRequest) (*v1.MigrateResponse, error) {
-	return func(ctx context.Context, req *v1.MigrateRequest) (*v1.MigrateResponse, error) {
-		resp, err := migrator.Migrate(ctx, req)
-		if err != nil {
-			setFailureHeaders(ctx, diagnostics.FromError(err))
-			return nil, responseError(err)
-		}
-
-		return resp, nil
+// Migrate executes the requested migration and returns response metadata and
+// collected migration logs.
+func (s *Server) Migrate(ctx context.Context, req *v1.MigrateRequest) (*v1.MigrateResponse, error) {
+	resp, err := s.migrator.Migrate(ctx, req)
+	if err != nil {
+		setFailureHeaders(ctx, diagnostics.FromError(err))
+		return nil, s.error(err)
 	}
+
+	return resp, nil
 }

--- a/internal/api/v1/transport/http/status.go
+++ b/internal/api/v1/transport/http/status.go
@@ -3,16 +3,14 @@ package http
 import (
 	"github.com/alexfalkowski/go-service/v2/context"
 	v1 "github.com/alexfalkowski/migrieren/api/migrieren/v1"
-	"github.com/alexfalkowski/migrieren/internal/api/v1/migrate"
 )
 
-func getStatus(migrator *migrate.Migrator) func(context.Context, *v1.StatusRequest) (*v1.StatusResponse, error) {
-	return func(ctx context.Context, req *v1.StatusRequest) (*v1.StatusResponse, error) {
-		resp, err := migrator.Status(ctx, req)
-		if err != nil {
-			return nil, responseError(err)
-		}
-
-		return resp, nil
+// Status reports the current migration version state for a configured database.
+func (s *Server) Status(ctx context.Context, req *v1.StatusRequest) (*v1.StatusResponse, error) {
+	resp, err := s.migrator.Status(ctx, req)
+	if err != nil {
+		return nil, s.error(err)
 	}
+
+	return resp, nil
 }


### PR DESCRIPTION
## What

- Add a receiver-based HTTP RPC transport adapter that mirrors the gRPC server shape.
- Register HTTP RPC routes through server methods for migrate, apply, status, and list database operations.
- Keep the existing migrator delegation, diagnostics headers, and response error mapping behavior intact.

## Why

- Aligning both transport packages around explicit server adapters keeps dependency injection and route ownership consistent.
- The change reduces closure-based handler wiring in the HTTP transport without changing the public RPC contract.

## Testing

- `make specs package=internal/api/v1` - passed
- `make specs package=internal/api/v1/transport/http` - passed
- `make golangci-lint package=internal/api/v1` - passed
- `make golangci-lint package=internal/api/v1/transport/http` - passed
- `make go-lint` - passed
- Full Cucumber feature coverage was not run locally.
