### PR TITLE
docs(readme): clarify migration service guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -400,7 +400,7 @@ Uses `github.com/alexfalkowski/go-service/v2/di` with Fx-style modules:
 - **Config-driven source/URL**: migration `source` and DB `url` are loaded via `go-service/v2/os.FS` from config values like `file:secrets/pg` (see `test/.config/server.yml`).
 - **DB URL scheme**: database driver expects `pgx5://...` and rewrites to `postgres://...` internally (`internal/migrate/database/database.go`).
 - **Checked-in test config is intentionally mixed**: `test/.config/server.yml` contains both valid and invalid database entries to exercise failure paths in feature tests.
-- **Health behavior in tests is asymmetric by design**: gRPC health for `migrieren.v1.Service` is expected to be healthy, while HTTP `/healthz` is expected to be unhealthy because per-database checks include intentionally invalid entries.
+- **Health behavior in tests is asymmetric by design**: gRPC health for `migrieren.v1.Service` is expected to be healthy, while HTTP `/migrieren/healthz` is expected to be unhealthy because per-database checks include intentionally invalid entries.
 
 ## 7) Tooling used by Make targets
 

--- a/README.md
+++ b/README.md
@@ -64,10 +64,13 @@ Install dependencies, build the binary, and start the server with the checked-in
 ```sh
 make dep
 make build
-./migrieren server -config file:test/.config/server.yml
+cd test
+../migrieren server -config file:.config/server.yml
 ```
 
-This builds `./migrieren` in the repository root.
+This builds `./migrieren` in the repository root. The checked-in test config is
+run from `test/` because its `file:...` references point at `test/secrets/` and
+its file migration sources are relative to that working directory.
 
 > [!WARNING]
 > The checked-in test config points Postgres at `localhost:5433` and OTLP tracing at `http://localhost:4318/v1/traces`. Start the local feature-test services or provide your own config before expecting migrations, health checks, and tracing to succeed.
@@ -220,7 +223,9 @@ tighten this once context-aware migrate v5 driver APIs are available.
 - `postgres` and `github` are used for successful migration scenarios.
 - `timeout` is used for deadline and cancellation scenarios.
 - `logs` is used for bounded migration log scenarios.
-- `missing_source`, `invalid_source`, `missing_url`, `invalid_url`, `invalid_db`, `invalid_quoted_table`, and `invalid_port` exist to exercise failure paths in feature tests.
+- `missing_source`, `invalid_source`, `missing_url`, `invalid_url`,
+  `invalid_db`, `invalid_quoted_table`, `invalid_incomplete_quoted_table`, and
+  `invalid_port` exist to exercise failure paths in feature tests.
 
 > [!IMPORTANT]
 > The checked-in config is a test fixture. Use it for local development and feature coverage, but do not treat it as a healthy production config.
@@ -440,18 +445,18 @@ HTTP uses the same names as response headers:
 When running with the shared service runtime, Migrieren exposes:
 
 - HTTP health endpoints:
-  - `/healthz`
-  - `/livez`
-  - `/readyz`
+  - `/migrieren/healthz`
+  - `/migrieren/livez`
+  - `/migrieren/readyz`
 - HTTP metrics:
-  - `/metrics`
+  - `/migrieren/metrics`
 - gRPC health checks for `migrieren.v1.Service`
 
 There is an important detail in the checked-in test config:
 
 - gRPC health for `migrieren.v1.Service` reports `SERVING`.
-- HTTP `/livez` and `/readyz` report healthy.
-- HTTP `/healthz` is expected to be unhealthy because the test config deliberately registers invalid database entries for failure-path coverage.
+- HTTP `/migrieren/livez` and `/migrieren/readyz` report healthy.
+- HTTP `/migrieren/healthz` is expected to be unhealthy because the test config deliberately registers invalid database entries for failure-path coverage.
 
 Health probes use internal registration names such as `noop` and `online`.
 Treat those names as reserved for health wiring rather than as migration
@@ -463,11 +468,11 @@ The sample test config also enables:
 - Prometheus metrics, and
 - OTLP tracing with `http://localhost:4318/v1/traces`.
 
-GitHub migration sources have one health-check exception: `/healthz` parses a
-configured `github://` source but does not open the remote repository during the
-health check. The remote source is opened during migration execution, so GitHub
-reachability failures can still appear on a migration request after health has
-reported on the configured target.
+GitHub migration sources have one health-check exception: `/migrieren/healthz`
+parses a configured `github://` source but does not open the remote repository
+during the health check. The remote source is opened during migration
+execution, so GitHub reachability failures can still appear on a migration
+request after health has reported on the configured target.
 
 ## 🛠️ Development
 

--- a/api/migrieren/v1/service.proto
+++ b/api/migrieren/v1/service.proto
@@ -150,6 +150,10 @@ service Service {
   // stopped requests, and Internal for configuration, source, database, final
   // version inspection, or migration failures.
   //
+  // Failures after request routing expose the same safe diagnostic trailers as
+  // Migrate, including migration-error, migration-log-count, migration-stage,
+  // and migration-log-last when those values are available.
+  //
   // As with Migrate and Status, strict request cancellation depends on upstream
   // migrate v4 context support, which is currently incomplete in some database
   // driver paths.

--- a/api/migrieren/v1/service_grpc.pb.go
+++ b/api/migrieren/v1/service_grpc.pb.go
@@ -58,6 +58,10 @@ type ServiceClient interface {
 	// stopped requests, and Internal for configuration, source, database, final
 	// version inspection, or migration failures.
 	//
+	// Failures after request routing expose the same safe diagnostic trailers as
+	// Migrate, including migration-error, migration-log-count, migration-stage,
+	// and migration-log-last when those values are available.
+	//
 	// As with Migrate and Status, strict request cancellation depends on upstream
 	// migrate v4 context support, which is currently incomplete in some database
 	// driver paths.
@@ -159,6 +163,10 @@ type ServiceServer interface {
 	// Errors use NotFound for unknown databases, Canceled/DeadlineExceeded for
 	// stopped requests, and Internal for configuration, source, database, final
 	// version inspection, or migration failures.
+	//
+	// Failures after request routing expose the same safe diagnostic trailers as
+	// Migrate, including migration-error, migration-log-count, migration-stage,
+	// and migration-log-last when those values are available.
 	//
 	// As with Migrate and Status, strict request cancellation depends on upstream
 	// migrate v4 context support, which is currently incomplete in some database

--- a/internal/diagnostics/doc.go
+++ b/internal/diagnostics/doc.go
@@ -1,0 +1,14 @@
+// Package diagnostics wraps migration errors with safe diagnostic values for
+// transport metadata.
+//
+// The package owns the repository's migration diagnostic key contract:
+// migration-error, migration-log-count, migration-stage, and
+// migration-log-last. These values are safe for HTTP response headers and gRPC
+// trailers because they expose error categories, configuration-resolution
+// stages, and bounded log metadata rather than raw database URLs, source URLs,
+// or secret values.
+//
+// Wrapped errors preserve their original cause for errors.Is and errors.As.
+// Transport packages decide how to expose the values, while migration packages
+// decide which operation failures should carry them.
+package diagnostics

--- a/test/lib/migrieren.rb
+++ b/test/lib/migrieren.rb
@@ -35,7 +35,7 @@ require 'migrieren/v1/service_services_pb'
 module Migrieren
   class << self
     ##
-    # Returns the observability client used by tests.
+    # Returns an observability client for feature-harness code.
     #
     # This client is provided by the `nonnative` test utilities and is available
     # to feature-harness code that needs to query or assert on telemetry emitted

--- a/test/lib/migrieren/v1/service_services_pb.rb
+++ b/test/lib/migrieren/v1/service_services_pb.rb
@@ -43,6 +43,10 @@ module Migrieren
         # stopped requests, and Internal for configuration, source, database, final
         # version inspection, or migration failures.
         #
+        # Failures after request routing expose the same safe diagnostic trailers as
+        # Migrate, including migration-error, migration-log-count, migration-stage,
+        # and migration-log-last when those values are available.
+        #
         # As with Migrate and Status, strict request cancellation depends on upstream
         # migrate v4 context support, which is currently incomplete in some database
         # driver paths.

--- a/test/log_migrations/README.md
+++ b/test/log_migrations/README.md
@@ -1,7 +1,8 @@
 # Log migration fixture
 
-This directory is a feature-test fixture for the bounded migration log scenario
-in `test/features/v1/transport/grpc/api.feature`.
+This directory is a feature-test fixture for migration log scenarios in the
+HTTP and gRPC API feature suites. The apply-all scenarios expect this fixture
+to converge at migration version `40`.
 
 The `logs` database target in `test/.config/server.yml` points at this source
 through `test/secrets/log_source`. It intentionally contains 40 tiny migrations


### PR DESCRIPTION
## What

- Correct the local quick-start command so the checked-in test fixture runs from the `test/` working directory that its `file:...` references expect.
- Document service-prefixed health and metrics endpoints, including the asymmetric `/migrieren/healthz` behavior in the test config.
- Fill in missing fixture and diagnostic documentation for `invalid_incomplete_quoted_table`, apply-all log migrations, `ApplyMigrations` failure metadata, and the diagnostics package owner contract.

## Why

- Readers could copy a root-level server command that cannot resolve the checked-in fixture paths, then debug a false migration/config failure.
- Operators and contributors need the service-prefixed operational paths and generated API comments to match the routes and diagnostics exercised by the feature harness.

## Testing

- `make proto-generate` - passed
- `make proto-lint` - passed
- `make specs` - passed
- `make lint` - passed
- `make features` - passed, 78 scenarios and 177 steps
- `git diff --check` - passed
- `make proto-stale` - inconclusive because the target fails on any intentional working-tree diff after generation; generated outputs were refreshed and reviewed.

AI-assisted-by: [Codex](https://openai.com/codex/)
