### PR TITLE
feat(status): emit diagnostics for inspection failures

### DIFF
--- a/internal/api/v1/transport/grpc/status.go
+++ b/internal/api/v1/transport/grpc/status.go
@@ -3,12 +3,14 @@ package grpc
 import (
 	"github.com/alexfalkowski/go-service/v2/context"
 	v1 "github.com/alexfalkowski/migrieren/api/migrieren/v1"
+	"github.com/alexfalkowski/migrieren/internal/diagnostics"
 )
 
 // Status reports the current migration version state for a configured database.
 func (s *Server) Status(ctx context.Context, req *v1.StatusRequest) (*v1.StatusResponse, error) {
 	resp, err := s.migrator.Status(ctx, req)
 	if err != nil {
+		setFailureTrailer(ctx, diagnostics.FromError(err))
 		return nil, s.error(err)
 	}
 

--- a/internal/api/v1/transport/http/status.go
+++ b/internal/api/v1/transport/http/status.go
@@ -3,12 +3,14 @@ package http
 import (
 	"github.com/alexfalkowski/go-service/v2/context"
 	v1 "github.com/alexfalkowski/migrieren/api/migrieren/v1"
+	"github.com/alexfalkowski/migrieren/internal/diagnostics"
 )
 
 // Status reports the current migration version state for a configured database.
 func (s *Server) Status(ctx context.Context, req *v1.StatusRequest) (*v1.StatusResponse, error) {
 	resp, err := s.migrator.Status(ctx, req)
 	if err != nil {
+		setFailureHeaders(ctx, diagnostics.FromError(err))
 		return nil, s.error(err)
 	}
 

--- a/test/features/v1/transport/grpc/api.feature
+++ b/test/features/v1/transport/grpc/api.feature
@@ -109,6 +109,10 @@ Feature: gRPC API
     When I request migration status with gRPC:
       | database | missing_url |
     Then I should receive an invalid migration from gRPC
+    And I should receive failure diagnostics from gRPC:
+      | error | invalid_config |
+      | logs  | empty          |
+      | stage | url            |
 
   Scenario Outline: Reject <case> migration version
     When I request to migrate with gRPC:

--- a/test/features/v1/transport/http/api.feature
+++ b/test/features/v1/transport/http/api.feature
@@ -109,6 +109,10 @@ Feature: HTTP API
     When I request migration status with HTTP:
       | database | missing_url |
     Then I should receive an invalid migration from HTTP
+    And I should receive failure diagnostics from HTTP:
+      | error | invalid_config |
+      | logs  | empty          |
+      | stage | url            |
 
   Scenario Outline: Reject <case> migration version
     When I request to migrate with HTTP:


### PR DESCRIPTION
## What

- Adds safe failure diagnostics metadata to migration inspection failures over both HTTP and gRPC.
- Extends the existing misconfigured database scenarios to assert the `invalid_config` and `url` diagnostic values for the non-mutating lookup path.
- Keeps response codes and response bodies unchanged; this only adds the same headers/trailers already used by mutating migration calls.

## Why

- Operators should get the same safe configuration-failure context from non-mutating inspection calls that they already get from migrate/apply failures.
- This lets clients diagnose a bad configured database URL without issuing a mutating migration request just to obtain `migration-error` or `migration-stage` metadata.

## Testing

- `make lint` - passed
- `make specs` - passed; compiled packages and ran the repository Go test target, which currently has 0 Go test cases in these packages.
- `make features feature=features/v1/transport/http/api.feature` - not run to completion; blocked before scenarios by missing local Postgres on `localhost:5432`.
- `make features feature=features/v1/transport/grpc/api.feature` - not run to completion; blocked before scenarios by missing local Postgres on `localhost:5432`.

AI-assisted-by: [Codex](https://openai.com/codex/)
