### PR TITLE
docs(readme): explain dirty-state repair boundary

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -94,6 +94,19 @@ This refreshes Go modules and updates `vendor/` (and also ensures Ruby gems for 
   upstream-supported hook becomes available, or the project explicitly decides
   to own a local pgx driver wrapper/fork.
 
+### Dirty migration repair is not a normal feature gap
+
+- Migrieren intentionally reports dirty migration state through `Status`, but
+  does not expose a public force/repair endpoint for clearing dirty migration
+  metadata.
+- A remote force/repair API would be destructive metadata surgery: the service
+  can verify migration table state, but cannot prove the operator correctly
+  repaired the real schema or data before clearing the dirty flag.
+- Reviewers should not keep recording the absence of a force-version,
+  repair-dirty, or clear-dirty RPC as a regular feature gap. Raise it only if
+  the project explicitly asks for a dedicated product/security design covering
+  guardrails, auditability, documentation, and test strategy.
+
 ### Health probe names are reserved by convention
 
 - Health wiring uses internal probe names such as `noop` and `online`.

--- a/README.md
+++ b/README.md
@@ -327,6 +327,14 @@ database: "postgres"
 > not accept Migrieren's request context until the upstream project provides
 > context-aware driver APIs.
 
+Migrieren intentionally does not expose a public force-version or dirty-state
+repair RPC. Dirty status means an operator must investigate the failed
+migration and repair the database state outside this service before any
+migration metadata is changed. A remote repair endpoint would be destructive
+metadata surgery that Migrieren cannot validate generically, because the service
+cannot prove the real schema or data was repaired correctly for every
+application.
+
 ### 📋 Database discovery
 
 `migrieren.v1.Service/ListDatabases` reports configured logical database names


### PR DESCRIPTION
## What

- Adds reviewer guidance that dirty-state force/repair endpoints should not be recorded as ordinary feature gaps.
- Documents for operators that Migrieren reports dirty status but intentionally does not expose a public dirty-state repair RPC.
- Leaves migration behavior unchanged; this only clarifies the product boundary around destructive migration metadata repair.

## Why

- A remote force-version API would be destructive metadata surgery that Migrieren cannot validate generically.
- Capturing the boundary in both repository guidance and user-facing API docs avoids repeatedly resurfacing an unsafe, hard-to-test feature proposal.

## Testing

- `make lint` - passed

AI-assisted-by: [Codex](https://openai.com/codex/)
