### PR TITLE
docs(readme): clarify migration execution boundary

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -107,6 +107,17 @@ This refreshes Go modules and updates `vendor/` (and also ensures Ruby gems for 
   the project explicitly asks for a dedicated product/security design covering
   guardrails, auditability, documentation, and test strategy.
 
+### Step-based migration execution is not desired
+
+- Migrieren intentionally keeps public execution choices to:
+  - `Migrate` for an explicit target version chosen by the caller.
+  - `ApplyMigrations` for converging to the latest available up migration.
+- Do not keep recording step-based up/down execution, rollback-by-step,
+  all-down, or version-zero migration requests as feature gaps by default.
+  Operators that need to move backward should choose an explicit target version
+  and call `Migrate`; hidden source-topology step execution is not part of the
+  current product direction.
+
 ### Health probe names are reserved by convention
 
 - Health wiring uses internal probe names such as `noop` and `online`.

--- a/README.md
+++ b/README.md
@@ -296,6 +296,11 @@ database: "postgres"
 > Request cancellation and deadlines are honored around the migration call, but
 > strict cancellation still depends on upstream context-aware driver support in
 > some database paths.
+>
+> Migrieren intentionally does not expose step-based up/down, rollback-by-step,
+> all-down, or version-zero migration APIs. Use `Migrate` when the caller knows
+> the target version, or `ApplyMigrations` to converge to the latest available
+> up migration.
 
 ### 🔎 Migration status
 


### PR DESCRIPTION
## What

- Document that Migrieren intentionally supports explicit target-version migration and apply-to-latest execution, not step-based up/down, rollback-by-step, all-down, or version-zero migration APIs.
- Add AGENTS guidance so future feature-gap reviews do not keep recording step-based migration execution as desired product work.

## Why

- The project direction is to use `Migrate` when callers know the target version and `ApplyMigrations` when callers want the latest available up migration.
- This prevents the invalidated step-based execution proposal from becoming recurring review or planning noise.

## Testing

- `git diff --check` - passed
- `make lint` - passed
