### PR TITLE
test(fault): cover stalled postgres dependency handling

### DIFF
--- a/test/features/health/transport/http/observability.feature
+++ b/test/features/health/transport/http/observability.feature
@@ -7,6 +7,11 @@ Feature: Observability
     When the system requests the "health" with HTTP
     Then the system should respond with an unhealthy status with HTTP
 
+  @reset
+  Scenario: Health with a timed out Postgres dependency
+    Given I set the proxy for service 'postgres' to 'timeout'
+    Then I should see "postgres" as unhealthy
+
   Scenario: Liveness with HTTP
     When the system requests the "liveness" with HTTP
     Then the system should respond with a healthy status with HTTP

--- a/test/features/step_definitions/v1/transport/http/migrate_steps.rb
+++ b/test/features/step_definitions/v1/transport/http/migrate_steps.rb
@@ -25,6 +25,10 @@ Then('I should receive an invalid argument migration from HTTP') do
   expect(@response.code).to eq(400)
 end
 
+Then('I should receive a timed out migration from HTTP') do
+  expect(@response).to be_a(RestClient::Exceptions::ReadTimeout)
+end
+
 def request_with_http(table)
   rows = table.rows_hash
   opts = Migrieren.http_options(
@@ -35,4 +39,6 @@ def request_with_http(table)
   )
 
   Migrieren::V1.server_http.migrate(rows['database'], rows['version'].to_i, opts)
+rescue StandardError => e
+  e
 end

--- a/test/features/v1/transport/grpc/migrate.feature
+++ b/test/features/v1/transport/grpc/migrate.feature
@@ -112,3 +112,12 @@ Feature: gRPC migrate API
       | database | postgres |
       | version  |        1 |
     Then I should receive an invalid migration from gRPC
+
+  @reset
+  Scenario: Stop migration when Postgres times out
+    Given I set the proxy for service 'postgres' to 'timeout'
+    And I should see "postgres" as unhealthy
+    When I request to migrate with gRPC:
+      | database | postgres |
+      | version  |        1 |
+    Then I should receive a stopped deadline migration from gRPC

--- a/test/features/v1/transport/http/migrate.feature
+++ b/test/features/v1/transport/http/migrate.feature
@@ -88,3 +88,12 @@ Feature: HTTP migrate API
       | database | postgres |
       | version  |        1 |
     Then I should receive an invalid migration from HTTP
+
+  @reset
+  Scenario: Stop migration when Postgres times out
+    Given I set the proxy for service 'postgres' to 'timeout'
+    And I should see "postgres" as unhealthy
+    When I request to migrate with HTTP:
+      | database | postgres |
+      | version  |        1 |
+    Then I should receive a timed out migration from HTTP


### PR DESCRIPTION
## What

- Add Cucumber coverage for a timed-out Postgres dependency through the nonnative fault-injection proxy.
- Assert HTTP health marks the `postgres` dependency unhealthy when the proxy stalls.
- Add gRPC and HTTP migrate scenarios for the stalled dependency; gRPC expects stopped deadline behavior and HTTP asserts the bounded client read timeout observed for this path.

## Why

- The harness already covered hard connection closure, but not a dependency that accepts TCP and stops responding.
- This protects timeout handling at health and migration boundaries for the Postgres proxy.

## Testing

- `zsh -lic 'gmake features feature=features/health/transport/http/observability.feature'` - passed
- `zsh -lic 'gmake features feature=features/v1/transport/grpc/migrate.feature'` - passed
- `zsh -lic 'gmake features feature=features/v1/transport/http/migrate.feature'` - passed
- `zsh -lic 'gmake lint'` - passed
- The HTTP migrate scenario documents that the stalled DB path currently reaches the feature harness as `RestClient::Exceptions::ReadTimeout`, not as an HTTP 504 response.

AI-assisted-by: [Codex](https://openai.com/codex/)
