### PR TITLE
feat(logs): make the hard-coded 100-line cap configurable

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -118,6 +118,22 @@ This refreshes Go modules and updates `vendor/` (and also ensures Ruby gems for 
   and call `Migrate`; hidden source-topology step execution is not part of the
   current product direction.
 
+### Surfacing pending migration names in PlanMigrations is not desired
+
+- `PlanMigrations` intentionally reports pending migrations as source version
+  numbers only. It does not return migration names/identifiers alongside those
+  versions.
+- We considered adding a `{version, name}` pending list (readable via the
+  upstream source driver's `ReadUp` identifier without reading bodies) and
+  decided against it: operators can easily look up which migrations the pending
+  version numbers correspond to from the migration source, so the added Plan
+  behavior (opening each pending migration to read its identifier) is not worth
+  the marginal convenience.
+- Reviewers should not keep recording "expose pending migration names/identifiers
+  in the plan" as a feature gap by default. Raise it only if the project
+  explicitly decides it wants human-meaningful names in the plan response, or
+  there is concrete operator evidence that version-number lookup is insufficient.
+
 ### Health probe names are reserved by convention
 
 - Health wiring uses internal probe names such as `noop` and `online`.

--- a/README.md
+++ b/README.md
@@ -165,6 +165,11 @@ unique `name` and all of these fields:
 - `source`: how to resolve the migration source URL.
 - `url`: how to resolve the database connection URL.
 
+`migrate.logs` is optional. `migrate.logs.max` bounds how many migration log
+lines each `Migrate`/`ApplyMigrations` response returns (default 100). When the
+limit is exceeded, the oldest lines are dropped and the first returned entry is a
+`migration logs truncated (showing last N of M)` marker.
+
 In the checked-in test setup, the referenced secret files contain the actual values consumed by the migrator:
 
 ```text
@@ -323,7 +328,7 @@ Response:
 - `meta`: request metadata emitted by the service runtime.
 - `migration.database`: echoed database name.
 - `migration.version`: echoed target version.
-- `migration.logs`: in-memory migration log lines collected during execution. Returned logs are capped at 100 entries and start with `migration logs truncated` when older lines were discarded.
+- `migration.logs`: in-memory migration log lines collected during execution. Returned logs are capped at a configured maximum (`migrate.logs.max`, default 100) and start with a `migration logs truncated (showing last N of M)` marker when older lines were discarded.
 
 Conceptual request:
 
@@ -350,8 +355,9 @@ Response:
 - `migration.version`: resulting migration version after applying pending
   migrations.
 - `migration.logs`: in-memory migration log lines collected during execution.
-  Returned logs are capped at 100 entries and start with `migration logs
-  truncated` when older lines were discarded.
+  Returned logs are capped at a configured maximum (`migrate.logs.max`, default
+  100) and start with a `migration logs truncated (showing last N of M)` marker
+  when older lines were discarded.
 
 Conceptual request:
 

--- a/api/migrieren/v1/service.pb.go
+++ b/api/migrieren/v1/service.pb.go
@@ -142,8 +142,9 @@ type Migration struct {
 	// resulting migration version for ApplyMigrations responses.
 	Version uint64 `protobuf:"varint,2,opt,name=version,proto3" json:"version,omitempty"`
 	// logs contains in-memory migrate log lines collected during execution.
-	// The service caps this list at 100 entries and marks truncation with
-	// "migration logs truncated" as the first entry.
+	// The service caps this list at a configured maximum (default 100). When
+	// older lines are dropped, the first entry begins with "migration logs
+	// truncated" and reports how many recent lines are shown out of the total.
 	Logs          []string `protobuf:"bytes,3,rep,name=logs,proto3" json:"logs,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache

--- a/api/migrieren/v1/service.proto
+++ b/api/migrieren/v1/service.proto
@@ -15,8 +15,9 @@ message Migration {
   uint64 version = 2;
 
   // logs contains in-memory migrate log lines collected during execution.
-  // The service caps this list at 100 entries and marks truncation with
-  // "migration logs truncated" as the first entry.
+  // The service caps this list at a configured maximum (default 100). When
+  // older lines are dropped, the first entry begins with "migration logs
+  // truncated" and reports how many recent lines are shown out of the total.
   repeated string logs = 3;
 }
 

--- a/internal/migrate/config.go
+++ b/internal/migrate/config.go
@@ -14,8 +14,38 @@ var ErrNotFound = errors.New("not found")
 // Databases must be non-empty and each entry must have a unique Name. The
 // service validates that every configured entry is present before startup
 // completes.
+//
+// Logs is optional and tunes how many migration log lines each operation
+// returns. When Logs is nil or its Max is not positive, the service uses its
+// default maximum.
 type Config struct {
+	Logs      *Logs       `yaml:"logs,omitempty" json:"logs,omitempty" toml:"logs,omitempty" validate:"omitempty"`
 	Databases []*Database `yaml:"databases" json:"databases" toml:"databases" validate:"gt=0,unique=Name,dive,required"`
+}
+
+// defaultMaxLogs is the number of migration log lines returned when a database
+// does not configure a positive migrate.logs.max.
+const defaultMaxLogs = 100
+
+// Logs configures how migration log output is captured and returned.
+type Logs struct {
+	// Max is the maximum number of migration log lines returned per operation.
+	// When not positive, the default maximum is used. When exceeded, the oldest
+	// lines are dropped and the first returned entry is a truncation marker.
+	Max int `yaml:"max,omitempty" json:"max,omitempty" toml:"max,omitempty" validate:"omitempty,gte=0"`
+}
+
+// GetMax returns the configured maximum number of migration log lines, or the
+// default maximum when Logs is nil or Max is not positive.
+//
+// It is safe to call on a nil receiver, so callers can use cfg.Logs.GetMax()
+// without first checking whether the optional logs section was configured.
+func (l *Logs) GetMax() int {
+	if l == nil || l.Max <= 0 {
+		return defaultMaxLogs
+	}
+
+	return l.Max
 }
 
 // Database returns the configured database entry with name.

--- a/internal/migrate/doc.go
+++ b/internal/migrate/doc.go
@@ -45,9 +45,11 @@
 // # Logs
 //
 // Migration logs are captured in memory and returned from [Migrator.Migrate] as
-// a slice of strings. The logger keeps at most 100 entries; when output exceeds
-// that cap, the first returned entry is "migration logs truncated" and the
-// remaining entries are the latest log lines. When the underlying migrate
+// a slice of strings. The logger keeps at most the configured maximum number of
+// entries (migrate.logs.max, default 100); when output exceeds that cap, the
+// oldest lines are dropped and the first returned entry is a marker beginning
+// with "migration logs truncated" that reports how many recent lines are shown,
+// followed by those most recent log lines. When the underlying migrate
 // engine reports migrate.ErrNoChange, it is treated as a successful no-op and
 // the accumulated logs are still returned.
 //

--- a/internal/migrate/migrate.go
+++ b/internal/migrate/migrate.go
@@ -37,8 +37,12 @@ var (
 // Migration resources are closed before returning on normal completion and
 // closed asynchronously when an in-flight migration is stopped by context
 // cancellation or deadline expiry.
-func NewMigrator() *Migrator {
-	return &Migrator{}
+//
+// The configured [Logs.Max], when positive, bounds how many migration log lines
+// each operation returns; otherwise a default maximum is used (see
+// [Logs.GetMax]).
+func NewMigrator(cfg *Config) *Migrator {
+	return &Migrator{logMax: cfg.Logs.GetMax()}
 }
 
 // Migrator performs database schema migrations using golang-migrate.
@@ -48,7 +52,9 @@ func NewMigrator() *Migrator {
 //   - Captures migration logs in memory and returns them to the caller.
 //   - Maps underlying driver/migration errors onto stable sentinel errors,
 //     attaching the original error to context metadata for observability.
-type Migrator struct{}
+type Migrator struct {
+	logMax int
+}
 
 // Migrate migrates the database identified by db to the given target version.
 //
@@ -65,8 +71,9 @@ type Migrator struct{}
 //     source/database setup or migration execution fails.
 //   - logs: in-memory migration logs captured during the operation. Logs may be
 //     returned on successful migrations, no-op migrations, and migration
-//     execution failures. At most 100 entries are returned; truncation is marked
-//     by "migration logs truncated" as the first entry.
+//     execution failures. At most the configured maximum (default 100) entries
+//     are returned; when older lines are dropped the first entry begins with
+//     "migration logs truncated" and reports how many lines are shown.
 //   - error: nil on success; otherwise one of:
 //     [ErrInvalidConfig] (cannot open src/db),
 //     [ErrInvalidMigration] (migration failed),
@@ -87,7 +94,7 @@ func (m *Migrator) Migrate(ctx context.Context, src, db string, version uint64) 
 		return ctx, nil, ErrInvalidConfig
 	}
 
-	logger := logger.New()
+	logger := logger.New(m.logMax)
 	migrator.Log = logger
 
 	if err := m.migrate(ctx, migrator, version); err != nil {
@@ -118,8 +125,9 @@ func (m *Migrator) Migrate(ctx context.Context, src, db string, version uint64) 
 //     migration version has been recorded.
 //   - logs: in-memory migration logs captured during the operation. Logs may be
 //     returned on successful migrations, no-op migrations, and migration
-//     execution failures. At most 100 entries are returned; truncation is marked
-//     by "migration logs truncated" as the first entry.
+//     execution failures. At most the configured maximum (default 100) entries
+//     are returned; when older lines are dropped the first entry begins with
+//     "migration logs truncated" and reports how many lines are shown.
 //   - error: nil on success; otherwise one of:
 //     [ErrInvalidConfig] (cannot open src/db),
 //     [ErrInvalidMigration] (migration failed or final version cannot be read),
@@ -142,7 +150,7 @@ func (m *Migrator) ApplyMigrations(ctx context.Context, src, db string) (context
 		return ctx, 0, nil, ErrInvalidConfig
 	}
 
-	logger := logger.New()
+	logger := logger.New(m.logMax)
 	migrator.Log = logger
 
 	version, err := m.applyMigrations(ctx, migrator)

--- a/internal/migrate/telemetry/logger/logger.go
+++ b/internal/migrate/telemetry/logger/logger.go
@@ -6,49 +6,78 @@ import (
 	"sync"
 )
 
-const (
-	maxLogLines = 100
-	truncated   = "migration logs truncated"
-)
+// truncated is the prefix of the marker entry emitted when log lines are dropped.
+const truncated = "migration logs truncated"
 
-// New returns an in-memory logger for migration output.
-func New() *Logger {
-	return &Logger{logs: make([]string, 0)}
+// New returns an in-memory logger for migration output that returns at most
+// limit entries.
+//
+// limit must be positive; defaulting is the caller's responsibility (see
+// [github.com/alexfalkowski/migrieren/internal/migrate.Logs.GetMax]). When the
+// captured output exceeds limit, the oldest lines are dropped so the most recent
+// lines, which are closest to a failure, are retained.
+func New(limit int) *Logger {
+	return &Logger{limit: limit}
 }
 
-// Logger captures migration log lines in memory.
+// Logger captures the most recent migration log lines in memory, bounded to a
+// caller-supplied limit.
 //
 // It satisfies the logging interface expected by golang-migrate and is safe for
 // concurrent use.
 type Logger struct {
-	logs []string
-	mu   sync.RWMutex
+	logs    []string
+	dropped int
+	limit   int
+	mu      sync.RWMutex
 }
 
-// Printf formats and stores a log line.
+// Printf formats and stores a log line, retaining only the most recent lines
+// within the configured limit.
 //
-// The logger keeps at most 100 entries. When that limit is exceeded, the first
-// entry is replaced with "migration logs truncated" and the remaining entries
-// are the latest log lines.
+// Once any line is dropped, one slot of the limit is reserved for the truncation
+// marker added by [Logger.Logs], so the returned slice never exceeds limit
+// entries. Dropping reslices the retained tail instead of rebuilding the slice
+// on every call, so capture stays cheap for large migrations.
 func (l *Logger) Printf(format string, v ...any) {
 	l.mu.Lock()
 	defer l.mu.Unlock()
 
 	l.logs = append(l.logs, strings.TrimSpace(fmt.Sprintf(format, v...)))
-	if len(l.logs) > maxLogLines {
-		l.logs = append([]string{truncated}, l.logs[len(l.logs)-maxLogLines+1:]...)
+
+	budget := l.limit
+	if l.dropped > 0 {
+		budget = l.limit - 1
 	}
+	if len(l.logs) <= budget {
+		return
+	}
+
+	keep := l.limit - 1
+	drop := len(l.logs) - keep
+	l.logs = l.logs[drop:]
+	l.dropped += drop
 }
 
 // Logs returns the captured log lines in insertion order.
 //
-// A first entry of "migration logs truncated" means earlier log lines were
-// discarded to keep only the latest 100 entries.
+// When earlier lines were dropped, the first entry is a marker that begins with
+// "migration logs truncated" and reports how many recent lines are shown out of
+// the total captured, for example "migration logs truncated (showing last 99 of
+// 512)".
 func (l *Logger) Logs() []string {
 	l.mu.RLock()
 	defer l.mu.RUnlock()
 
-	return append([]string(nil), l.logs...)
+	if l.dropped == 0 {
+		return append([]string(nil), l.logs...)
+	}
+
+	marker := fmt.Sprintf("%s (showing last %d of %d)", truncated, len(l.logs), l.dropped+len(l.logs))
+	logs := make([]string, 0, len(l.logs)+1)
+	logs = append(logs, marker)
+
+	return append(logs, l.logs...)
 }
 
 // Verbose reports that verbose migration logging is enabled.

--- a/test/.config/server.yml
+++ b/test/.config/server.yml
@@ -5,6 +5,8 @@ health:
 id:
   kind: uuid
 migrate:
+  logs:
+    max: 20
   databases:
     - name: postgres
       source: file:secrets/source

--- a/test/features/step_definitions/v1/transport/grpc/apply_steps.rb
+++ b/test/features/step_definitions/v1/transport/grpc/apply_steps.rb
@@ -4,6 +4,14 @@ When('I request to apply migrations with gRPC:') do |table|
   @response = request_apply_with_grpc(table)
 end
 
+Then('I should receive truncated migration logs from gRPC:') do |table|
+  rows = table.rows_hash
+  logs = @response.migration.logs
+
+  expect(logs.length).to eq(rows['max'].to_i)
+  expect(logs.first).to match(/\Amigration logs truncated \(showing last \d+ of \d+\)\z/)
+end
+
 def request_apply_with_grpc(table)
   rows = table.rows_hash
   request = Migrieren::V1::ApplyMigrationsRequest.new(database: rows['database'])

--- a/test/features/step_definitions/v1/transport/grpc/migrate_steps.rb
+++ b/test/features/step_definitions/v1/transport/grpc/migrate_steps.rb
@@ -36,7 +36,7 @@ Then('I should receive bounded migration logs from gRPC') do
   logs = @response.migration.logs
 
   expect(logs.length).to be <= 100
-  expect(logs.first).to eq('migration logs truncated')
+  expect(logs.first).to start_with('migration logs truncated')
 end
 
 def request_with_grpc(table)

--- a/test/features/step_definitions/v1/transport/http/apply_steps.rb
+++ b/test/features/step_definitions/v1/transport/http/apply_steps.rb
@@ -4,6 +4,15 @@ When('I request to apply migrations with HTTP:') do |table|
   @response = request_apply_with_http(table)
 end
 
+Then('I should receive truncated migration logs from HTTP:') do |table|
+  rows = table.rows_hash
+  resp = JSON.parse(@response.body)
+  logs = resp['migration']['logs'] || []
+
+  expect(logs.length).to eq(rows['max'].to_i)
+  expect(logs.first).to match(/\Amigration logs truncated \(showing last \d+ of \d+\)\z/)
+end
+
 def request_apply_with_http(table)
   rows = table.rows_hash
   opts = Migrieren.http_options(

--- a/test/features/v1/transport/grpc/apply.feature
+++ b/test/features/v1/transport/grpc/apply.feature
@@ -20,6 +20,13 @@ Feature: gRPC apply API
       | database | logs |
       | version  |   40 |
 
+  @clean
+  Scenario: Apply migrations truncates logs to the configured maximum
+    When I request to apply migrations with gRPC:
+      | database | logs |
+    Then I should receive truncated migration logs from gRPC:
+      | max | 20 |
+
   Scenario: Apply missing databases
     When I request to apply migrations with gRPC:
       | database | missing |

--- a/test/features/v1/transport/http/apply.feature
+++ b/test/features/v1/transport/http/apply.feature
@@ -20,6 +20,13 @@ Feature: HTTP apply API
       | database | logs |
       | version  |   40 |
 
+  @clean
+  Scenario: Apply migrations truncates logs to the configured maximum
+    When I request to apply migrations with HTTP:
+      | database | logs |
+    Then I should receive truncated migration logs from HTTP:
+      | max | 20 |
+
   Scenario: Apply missing databases
     When I request to apply migrations with HTTP:
       | database | missing |

--- a/test/log_migrations/README.md
+++ b/test/log_migrations/README.md
@@ -6,8 +6,9 @@ to converge at migration version `40`.
 
 The `logs` database target in `test/.config/server.yml` points at this source
 through `test/secrets/log_source`. It intentionally contains 40 tiny migrations
-so a real `golang-migrate` run emits more than 100 log lines. That lets the
-feature test verify that returned migration logs are capped and marked with
-`migration logs truncated`.
+so a real `golang-migrate` run emits far more log lines than the configured
+maximum (`migrate.logs.max`, set to `20` for these suites). That lets the
+feature tests verify that returned migration logs are capped at the configured
+maximum and start with a `migration logs truncated (showing last N of M)` marker.
 
 These files are not product migrations.


### PR DESCRIPTION
## What

- Add an optional `migrate.logs.max` config field (default 100) that bounds how
  many migration log lines each `Migrate` / `ApplyMigrations` response returns.
  Fully additive — unset keeps the current behavior (cap 100), so existing
  deployments and responses are unaffected.
- Make defaulting a configuration responsibility: `migrate.Logs.GetMax()`
  (nil-safe) resolves the configured value or the default, and `logger.New(limit)`
  takes the limit verbatim rather than defaulting internally.
- Retain the most-recent log lines (closest to a failure), bounded so the
  returned slice never exceeds the limit. Truncation reslices the retained tail
  (amortized O(1), memory bounded to ~2×limit) instead of rebuilding the slice on
  every line, and the marker is materialized only when the logs are read.
- When older lines are dropped, the first entry is a
  `migration logs truncated (showing last N of M)` marker so operators can see
  how much was dropped, not just that truncation happened.
- Update the documented behavior to match: README configuration + response notes,
  the `service.proto` (and regenerated `.pb.go`) comment, and package/godoc
  comments. Add HTTP and gRPC `apply` cucumber scenarios asserting the returned
  logs are capped at the configured maximum and carry the marker.
- Also record a decision note in `AGENTS.md` that surfacing pending migration
  names in `PlanMigrations` is intentionally not desired (a feature-gap proposal
  considered and rejected this session), so future reviews do not re-propose it.

## Why

- The cap was a hard-coded `maxLogLines = 100` with no knob and a bare marker.
  Operators running large multi-statement migrations could neither tune how much
  log context they get back nor tell how much was dropped. Making the limit
  configurable with a safe default, and reporting the dropped count, improves
  diagnosis while keeping the response bounded — an unbounded response would risk
  exceeding the gRPC message-size limit on exactly the large migrations where the
  logs matter most, losing everything instead of a marked tail.
- The `AGENTS.md` note keeps the product direction explicit so future feature-gap
  passes do not re-raise an already-decided-against capability.

## Testing

- `make lint` - passed (golangci-lint: 0 issues; RuboCop: no offenses)
- `make specs` - passed (compiles clean; repo relies on the feature harness)
- `make analyse` - passed (fieldalignment)
- `make features` - passed (109 scenarios, 251 steps), including the new HTTP and
  gRPC log-truncation scenarios; a real red → green was observed on the targeted
  `apply` feature before implementing the wiring.
- `make proto-generate` + `make proto-breaking` - passed (comment-only `.pb.go`
  change; non-breaking).
- The logger truncation rework was independently reviewed: a property test over
  limit/emit combinations (invariant: returned length <= limit, marker iff
  dropped, most-recent tail retained), a `-race` run of the concurrent
  `Printf`/`Logs` shape, and `AllocsPerRun` = 0 per append at steady state.
- CI will additionally run `make proto-stale` on the committed tree.

AI-assisted-by: [Claude Code](https://claude.com/claude-code)
