### PR TITLE
feat(diagnostics): attribute setup failures safely

### DIFF
--- a/README.md
+++ b/README.md
@@ -565,17 +565,22 @@ Transport behavior is intentionally simple:
 
 The core migrator also treats `migrate.ErrNoChange` as a successful no-op and still returns any accumulated logs.
 
-For migration requests that pass request validation and then fail, the server
-also adds safe failure diagnostics. gRPC exposes them as trailers and HTTP
-exposes them as response headers without changing the HTTP status code or error
-body shape. This includes unknown database names and source/URL resolution
-failures as well as core migration failures; invalid version values return
-`InvalidArgument`/`400` before this diagnostic path runs.
+For Migrate, ApplyMigrations, PlanMigrations, and Status requests that pass
+request validation and then fail, the server adds safe failure diagnostics when
+they are available. gRPC exposes them as trailers and HTTP exposes them as
+response headers without changing the HTTP status code or error body shape.
+This includes unknown database names, source/database setup and
+reference-resolution failures, and core migration failures; invalid version
+values return `InvalidArgument`/`400` before this diagnostic path runs.
 
 - `migration-error`: one of `not_found`, `canceled`, `deadline_exceeded`,
   `invalid_config`, `invalid_migration`, or `unknown`.
 - `migration-log-count`: number of migration log lines returned.
-- `migration-stage`: `source` or `url` when configuration resolution failed.
+- `migration-stage`: `source` when migration-source setup or reference
+  resolution failed, or `url` when database setup or database-URL reference
+  resolution failed. `url` identifies the database-setup branch; it does not
+  imply malformed URL syntax. Later migration or database-inspection failures
+  omit this value.
 - `migration-log-last`: last migration log line when logs were captured.
 
 HTTP uses the same names as response headers:

--- a/api/migrieren/v1/service.proto
+++ b/api/migrieren/v1/service.proto
@@ -200,12 +200,13 @@ service Service {
   //
   // gRPC failures after request validation include trailers when the request
   // reaches the transport migrator. This includes unknown database names and
-  // source/URL resolution failures; pre-migration validation InvalidArgument
-  // responses do not use this trailer path.
+  // source/database setup or reference-resolution failures; pre-migration
+  // validation InvalidArgument responses do not use this trailer path.
   // - migration-error: not_found, canceled, deadline_exceeded, invalid_config,
   //   invalid_migration, or unknown.
   // - migration-log-count: the number of migration log lines returned.
-  // - migration-stage: source or url when configuration resolution failed.
+  // - migration-stage: source for source setup or resolution failures, or url
+  //   for database setup or URL-resolution failures.
   // - migration-log-last: the last migration log line when logs were captured.
   rpc Migrate(MigrateRequest) returns (MigrateResponse) {}
 
@@ -250,6 +251,11 @@ service Service {
   //
   // Errors use NotFound for unknown databases and Internal for configuration or
   // database inspection failures.
+  //
+  // Failures after request routing expose the same safe diagnostic trailers as
+  // Migrate when those values are available. Status does not open a migration
+  // source, so migration-stage is url when database setup or URL resolution
+  // fails.
   //
   // Status does not apply migration files, but strict request cancellation
   // depends on upstream migrate v4 context support, which is currently

--- a/api/migrieren/v1/service_grpc.pb.go
+++ b/api/migrieren/v1/service_grpc.pb.go
@@ -41,12 +41,13 @@ type ServiceClient interface {
 	//
 	// gRPC failures after request validation include trailers when the request
 	// reaches the transport migrator. This includes unknown database names and
-	// source/URL resolution failures; pre-migration validation InvalidArgument
-	// responses do not use this trailer path.
+	// source/database setup or reference-resolution failures; pre-migration
+	// validation InvalidArgument responses do not use this trailer path.
 	//   - migration-error: not_found, canceled, deadline_exceeded, invalid_config,
 	//     invalid_migration, or unknown.
 	//   - migration-log-count: the number of migration log lines returned.
-	//   - migration-stage: source or url when configuration resolution failed.
+	//   - migration-stage: source for source setup or resolution failures, or url
+	//     for database setup or URL-resolution failures.
 	//   - migration-log-last: the last migration log line when logs were captured.
 	Migrate(ctx context.Context, in *MigrateRequest, opts ...grpc.CallOption) (*MigrateResponse, error)
 	// ApplyMigrations applies all pending up migrations for a configured
@@ -88,6 +89,11 @@ type ServiceClient interface {
 	//
 	// Errors use NotFound for unknown databases and Internal for configuration or
 	// database inspection failures.
+	//
+	// Failures after request routing expose the same safe diagnostic trailers as
+	// Migrate when those values are available. Status does not open a migration
+	// source, so migration-stage is url when database setup or URL resolution
+	// fails.
 	//
 	// Status does not apply migration files, but strict request cancellation
 	// depends on upstream migrate v4 context support, which is currently
@@ -173,12 +179,13 @@ type ServiceServer interface {
 	//
 	// gRPC failures after request validation include trailers when the request
 	// reaches the transport migrator. This includes unknown database names and
-	// source/URL resolution failures; pre-migration validation InvalidArgument
-	// responses do not use this trailer path.
+	// source/database setup or reference-resolution failures; pre-migration
+	// validation InvalidArgument responses do not use this trailer path.
 	//   - migration-error: not_found, canceled, deadline_exceeded, invalid_config,
 	//     invalid_migration, or unknown.
 	//   - migration-log-count: the number of migration log lines returned.
-	//   - migration-stage: source or url when configuration resolution failed.
+	//   - migration-stage: source for source setup or resolution failures, or url
+	//     for database setup or URL-resolution failures.
 	//   - migration-log-last: the last migration log line when logs were captured.
 	Migrate(context.Context, *MigrateRequest) (*MigrateResponse, error)
 	// ApplyMigrations applies all pending up migrations for a configured
@@ -220,6 +227,11 @@ type ServiceServer interface {
 	//
 	// Errors use NotFound for unknown databases and Internal for configuration or
 	// database inspection failures.
+	//
+	// Failures after request routing expose the same safe diagnostic trailers as
+	// Migrate when those values are available. Status does not open a migration
+	// source, so migration-stage is url when database setup or URL resolution
+	// fails.
 	//
 	// Status does not apply migration files, but strict request cancellation
 	// depends on upstream migrate v4 context support, which is currently

--- a/internal/api/migrate/status.go
+++ b/internal/api/migrate/status.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/alexfalkowski/go-service/v2/bytes"
 	"github.com/alexfalkowski/go-service/v2/context"
+	"github.com/alexfalkowski/go-service/v2/strings"
 	"github.com/alexfalkowski/migrieren/internal/diagnostics"
 	"github.com/alexfalkowski/migrieren/internal/migrate"
 )
@@ -25,5 +26,14 @@ func (s *Migrator) Status(ctx context.Context, db string) (context.Context, *mig
 		return ctx, nil, diagnostics.InvalidConfig(err, diagnostics.StageURL)
 	}
 
-	return s.migrator.Status(ctx, bytes.String(url))
+	ctx, status, err := s.migrator.Status(ctx, bytes.String(url))
+	if err != nil {
+		if stage := diagnostics.Stage(err); !strings.IsEmpty(stage) {
+			return ctx, nil, diagnostics.InvalidConfig(err, stage)
+		}
+
+		return ctx, nil, err
+	}
+
+	return ctx, status, nil
 }

--- a/internal/diagnostics/diagnostics.go
+++ b/internal/diagnostics/diagnostics.go
@@ -5,6 +5,7 @@ import (
 	"strconv"
 
 	"github.com/alexfalkowski/go-service/v2/errors"
+	"github.com/alexfalkowski/go-service/v2/strings"
 	"github.com/alexfalkowski/migrieren/internal/migrate"
 )
 
@@ -21,18 +22,23 @@ const StageURL = "url"
 // The returned error unwraps to err, so errors.Is and errors.As continue to
 // match the original cause.
 func Error(err error, logs []string) error {
+	values := newValues(err, logs)
+	if stage := Stage(err); !strings.IsEmpty(stage) {
+		values["migration-stage"] = stage
+	}
+
 	return &diagnosticError{
 		err:    err,
-		values: newValues(err, logs),
+		values: values,
 	}
 }
 
 // InvalidConfig wraps err with diagnostics for a migration configuration
-// resolution failure.
+// setup or reference-resolution failure.
 func InvalidConfig(err error, stage string) error {
 	values := newValues(err, nil)
 	values["migration-error"] = invalidConfig
-	if stage != "" {
+	if !strings.IsEmpty(stage) {
 		values["migration-stage"] = stage
 	}
 
@@ -72,6 +78,26 @@ func failureKind(err error) string {
 	}
 }
 
+// Stage returns the safe migration setup stage carried by err.
+//
+// It returns an empty string when err did not result from source or database
+// setup, or when its stage is not part of the public diagnostic vocabulary.
+func Stage(err error) string {
+	staged, ok := errors.AsType[stagedError](err)
+	if !ok {
+		return strings.Empty
+	}
+
+	// Stages are emitted as public HTTP headers and gRPC trailers. Do not let an
+	// arbitrary error-provided value extend that contract or leak diagnostics.
+	switch stage := staged.Stage(); stage {
+	case StageSource, StageURL:
+		return stage
+	default:
+		return strings.Empty
+	}
+}
+
 // FromError returns the safe diagnostic values carried by err.
 //
 // If err does not carry diagnostics, FromError returns an empty map.
@@ -101,6 +127,11 @@ func (v Values) copy() Values {
 type diagnosticError struct {
 	err    error
 	values Values
+}
+
+type stagedError interface {
+	error
+	Stage() string
 }
 
 func (d *diagnosticError) Error() string {

--- a/internal/diagnostics/doc.go
+++ b/internal/diagnostics/doc.go
@@ -4,9 +4,9 @@
 // The package owns the repository's migration diagnostic key contract:
 // migration-error, migration-log-count, migration-stage, and
 // migration-log-last. These values are safe for HTTP response headers and gRPC
-// trailers because they expose error categories, configuration-resolution
-// stages, and bounded log metadata rather than raw database URLs, source URLs,
-// or secret values.
+// trailers because they expose error categories, source/database setup or
+// reference-resolution stages, and bounded log metadata rather than raw
+// database URLs, source URLs, or secret values.
 //
 // Wrapped errors preserve their original cause for errors.Is and errors.As.
 // Transport packages decide how to expose the values, while migration packages

--- a/internal/migrate/database/database.go
+++ b/internal/migrate/database/database.go
@@ -41,15 +41,36 @@ var telemetryAttrs = telemetry.WithAttributes(attributes.DBSystemNamePostgreSQL)
 func Open(ctx context.Context, databaseURL string) (database.Driver, error) {
 	u, err := url.Parse(databaseURL)
 	if err != nil {
-		return nil, ErrInvalidURL
+		return nil, &openError{err: ErrInvalidURL}
 	}
 
 	switch u.Scheme {
 	case "pgx5":
-		return openPGX(ctx, u)
+		driver, err := openPGX(ctx, u)
+		if err != nil {
+			return nil, &openError{err: err}
+		}
+
+		return driver, nil
 	default:
-		return nil, ErrUnsupportedDriver
+		return nil, &openError{err: ErrUnsupportedDriver}
 	}
+}
+
+type openError struct {
+	err error
+}
+
+func (e *openError) Error() string {
+	return e.err.Error()
+}
+
+func (e *openError) Unwrap() error {
+	return e.err
+}
+
+func (e *openError) Stage() string {
+	return "url"
 }
 
 func openPGX(ctx context.Context, u *url.URL) (database.Driver, error) {

--- a/internal/migrate/errors.go
+++ b/internal/migrate/errors.go
@@ -1,0 +1,32 @@
+package migrate
+
+import (
+	"github.com/alexfalkowski/go-service/v2/errors"
+	"github.com/alexfalkowski/go-service/v2/strings"
+)
+
+type invalidConfigError struct {
+	err error
+}
+
+func (e *invalidConfigError) Error() string {
+	return ErrInvalidConfig.Error()
+}
+
+func (e *invalidConfigError) Unwrap() error {
+	return ErrInvalidConfig
+}
+
+func (e *invalidConfigError) Stage() string {
+	staged, ok := errors.AsType[stagedError](e.err)
+	if !ok {
+		return strings.Empty
+	}
+
+	return staged.Stage()
+}
+
+type stagedError interface {
+	error
+	Stage() string
+}

--- a/internal/migrate/migrate.go
+++ b/internal/migrate/migrate.go
@@ -91,7 +91,7 @@ func (m *Migrator) Migrate(ctx context.Context, src, db string, version uint64) 
 	migrator, err := m.newMigrator(ctx, src, db)
 	if err != nil {
 		ctx = meta.WithAttributes(ctx, meta.NewPair("migrateError", meta.Error(err)))
-		return ctx, nil, ErrInvalidConfig
+		return ctx, nil, &invalidConfigError{err: err}
 	}
 
 	logger := logger.New(m.logMax)
@@ -147,7 +147,7 @@ func (m *Migrator) ApplyMigrations(ctx context.Context, src, db string) (context
 	migrator, err := m.newMigrator(ctx, src, db)
 	if err != nil {
 		ctx = meta.WithAttributes(ctx, meta.NewPair("migrateError", meta.Error(err)))
-		return ctx, 0, nil, ErrInvalidConfig
+		return ctx, 0, nil, &invalidConfigError{err: err}
 	}
 
 	logger := logger.New(m.logMax)

--- a/internal/migrate/pgx/pgx.go
+++ b/internal/migrate/pgx/pgx.go
@@ -77,10 +77,10 @@ func parseMigrationsTableOptions(query url.Values) (string, bool, error) {
 
 	migrationsTableQuoted, err := parseBoolOption(query, "x-migrations-table-quoted")
 	if err != nil {
-		return "", false, fmt.Errorf("unable to parse option x-migrations-table-quoted: %w", err)
+		return strings.Empty, false, fmt.Errorf("unable to parse option x-migrations-table-quoted: %w", err)
 	}
 	if migrationsTableQuoted && invalidQuotedMigrationsTable(migrationsTable) {
-		return "", false, fmt.Errorf(
+		return strings.Empty, false, fmt.Errorf(
 			"%w: x-migrations-table must be quoted when x-migrations-table-quoted is enabled, current value is %q",
 			ErrInvalidMigrationsTable, migrationsTable,
 		)

--- a/internal/migrate/plan.go
+++ b/internal/migrate/plan.go
@@ -78,7 +78,7 @@ func (m *Migrator) Plan(ctx context.Context, src, db string, target *uint64) (co
 	driver, err := source.Open(src)
 	if err != nil {
 		ctx = meta.WithAttributes(ctx, meta.NewPair("planError", meta.Error(err)))
-		return ctx, nil, ErrInvalidConfig
+		return ctx, nil, &invalidConfigError{err: err}
 	}
 	defer func() {
 		_ = driver.Close()

--- a/internal/migrate/source/github/github.go
+++ b/internal/migrate/source/github/github.go
@@ -156,7 +156,7 @@ func (d *Driver) Next(version uint) (uint, error) {
 func (d *Driver) ReadUp(version uint) (io.ReadCloser, string, error) {
 	migration, ok := d.migrations.Up(version)
 	if !ok {
-		return nil, "", &os.PathError{Op: fmt.Sprintf("read up version %d", version), Path: d.path, Err: os.ErrNotExist}
+		return nil, strings.Empty, &os.PathError{Op: fmt.Sprintf("read up version %d", version), Path: d.path, Err: os.ErrNotExist}
 	}
 
 	return d.read(migration)
@@ -168,7 +168,7 @@ func (d *Driver) ReadUp(version uint) (io.ReadCloser, string, error) {
 func (d *Driver) ReadDown(version uint) (io.ReadCloser, string, error) {
 	migration, ok := d.migrations.Down(version)
 	if !ok {
-		return nil, "", &os.PathError{Op: fmt.Sprintf("read down version %d", version), Path: d.path, Err: os.ErrNotExist}
+		return nil, strings.Empty, &os.PathError{Op: fmt.Sprintf("read down version %d", version), Path: d.path, Err: os.ErrNotExist}
 	}
 
 	return d.read(migration)
@@ -203,7 +203,7 @@ func (d *Driver) read(migration *source.Migration) (io.ReadCloser, string, error
 		context.Background(), d.owner, d.repository, path.Join(d.path, migration.Raw), d.options,
 	)
 	if err != nil {
-		return nil, "", err
+		return nil, strings.Empty, err
 	}
 
 	return reader, migration.Identifier, nil

--- a/internal/migrate/source/source.go
+++ b/internal/migrate/source/source.go
@@ -57,7 +57,28 @@ func Check(ctx context.Context, sourceURL string) error {
 //
 // Callers own the returned driver and must close it after successful opens.
 func Open(sourceURL string) (source.Driver, error) {
-	return source.Open(sourceURL)
+	driver, err := source.Open(sourceURL)
+	if err != nil {
+		return nil, &openError{err: err}
+	}
+
+	return driver, nil
+}
+
+type openError struct {
+	err error
+}
+
+func (e *openError) Error() string {
+	return e.err.Error()
+}
+
+func (e *openError) Unwrap() error {
+	return e.err
+}
+
+func (e *openError) Stage() string {
+	return "source"
 }
 
 // Versions returns all migration versions from driver in ascending order.

--- a/internal/migrate/status.go
+++ b/internal/migrate/status.go
@@ -54,7 +54,7 @@ func (m *Migrator) Status(ctx context.Context, db string) (context.Context, *Sta
 	driver, err := database.Open(ctx, db)
 	if err != nil {
 		ctx = meta.WithAttributes(ctx, meta.NewPair("statusError", meta.Error(err)))
-		return ctx, nil, ErrInvalidConfig
+		return ctx, nil, &invalidConfigError{err: err}
 	}
 	defer func() {
 		_ = driver.Close()

--- a/test/features/v1/transport/grpc/apply.feature
+++ b/test/features/v1/transport/grpc/apply.feature
@@ -32,12 +32,18 @@ Feature: gRPC apply API
       | database | missing |
     Then I should receive a not found migration from gRPC
 
-  Scenario Outline: Apply misconfigured databases
+  Scenario Outline: Return apply failure diagnostics
     When I request to apply migrations with gRPC:
       | database | <database> |
     Then I should receive an invalid migration from gRPC
+    And I should receive failure diagnostics from gRPC:
+      | error | <error> |
+      | logs  | <logs>  |
+      | stage | <stage> |
 
     Examples:
-      | database       |
-      | missing_source |
-      | missing_url    |
+      | database       | error          | logs  | stage  |
+      | missing_source | invalid_config | empty | source |
+      | missing_url    | invalid_config | empty | url    |
+      | invalid_source | invalid_config | empty | source |
+      | invalid_url    | invalid_config | empty | url    |

--- a/test/features/v1/transport/grpc/migrate.feature
+++ b/test/features/v1/transport/grpc/migrate.feature
@@ -82,7 +82,9 @@ Feature: gRPC migrate API
       | database                         | version | error             | logs    | stage  |
       | missing_source                   |       1 | invalid_config    | empty   | source |
       | missing_url                      |       1 | invalid_config    | empty   | url    |
-      | invalid_incomplete_quoted_table  |       1 | invalid_config    | empty   |        |
+      | invalid_source                   |       1 | invalid_config    | empty   | source |
+      | invalid_url                      |       1 | invalid_config    | empty   | url    |
+      | invalid_incomplete_quoted_table  |       1 | invalid_config    | empty   | url    |
       | postgres                         |       3 | invalid_migration | present |        |
 
   @clean

--- a/test/features/v1/transport/grpc/plan.feature
+++ b/test/features/v1/transport/grpc/plan.feature
@@ -150,3 +150,5 @@ Feature: gRPC plan API
       | database       | error          | logs  | stage  |
       | missing_source | invalid_config | empty | source |
       | missing_url    | invalid_config | empty | url    |
+      | invalid_source | invalid_config | empty | source |
+      | invalid_url    | invalid_config | empty | url    |

--- a/test/features/v1/transport/grpc/status.feature
+++ b/test/features/v1/transport/grpc/status.feature
@@ -28,14 +28,19 @@ Feature: gRPC status API
       | database | missing |
     Then I should receive a not found migration from gRPC
 
-  Scenario: Report misconfigured migration status
+  Scenario Outline: Report misconfigured migration status
     When I request migration status with gRPC:
-      | database | missing_url |
+      | database | <database> |
     Then I should receive an invalid migration from gRPC
     And I should receive failure diagnostics from gRPC:
-      | error | invalid_config |
-      | logs  | empty          |
-      | stage | url            |
+      | error | <error> |
+      | logs  | <logs>  |
+      | stage | <stage> |
+
+    Examples:
+      | database    | error          | logs  | stage |
+      | missing_url | invalid_config | empty | url   |
+      | invalid_url | invalid_config | empty | url   |
 
   @clean
   Scenario: Report dirty migration status

--- a/test/features/v1/transport/http/apply.feature
+++ b/test/features/v1/transport/http/apply.feature
@@ -56,3 +56,5 @@ Feature: HTTP apply API
       | database       | error          | logs  | stage  |
       | missing_source | invalid_config | empty | source |
       | missing_url    | invalid_config | empty | url    |
+      | invalid_source | invalid_config | empty | source |
+      | invalid_url    | invalid_config | empty | url    |

--- a/test/features/v1/transport/http/migrate.feature
+++ b/test/features/v1/transport/http/migrate.feature
@@ -78,6 +78,8 @@ Feature: HTTP migrate API
       | database        | version | error             | logs    | stage  |
       | missing_source  |       1 | invalid_config    | empty   | source |
       | missing_url     |       1 | invalid_config    | empty   | url    |
+      | invalid_source  |       1 | invalid_config    | empty   | source |
+      | invalid_url     |       1 | invalid_config    | empty   | url    |
       | postgres        |       3 | invalid_migration | present |        |
 
   @reset

--- a/test/features/v1/transport/http/plan.feature
+++ b/test/features/v1/transport/http/plan.feature
@@ -150,3 +150,5 @@ Feature: HTTP plan API
       | database       | error          | logs  | stage  |
       | missing_source | invalid_config | empty | source |
       | missing_url    | invalid_config | empty | url    |
+      | invalid_source | invalid_config | empty | source |
+      | invalid_url    | invalid_config | empty | url    |

--- a/test/features/v1/transport/http/status.feature
+++ b/test/features/v1/transport/http/status.feature
@@ -28,11 +28,16 @@ Feature: HTTP status API
       | database | missing |
     Then I should receive a not found migration from HTTP
 
-  Scenario: Report misconfigured migration status
+  Scenario Outline: Report misconfigured migration status
     When I request migration status with HTTP:
-      | database | missing_url |
+      | database | <database> |
     Then I should receive an invalid migration from HTTP
     And I should receive failure diagnostics from HTTP:
-      | error | invalid_config |
-      | logs  | empty          |
-      | stage | url            |
+      | error | <error> |
+      | logs  | <logs>  |
+      | stage | <stage> |
+
+    Examples:
+      | database    | error          | logs  | stage |
+      | missing_url | invalid_config | empty | url   |
+      | invalid_url | invalid_config | empty | url   |

--- a/test/lib/migrieren/v1/service_services_pb.rb
+++ b/test/lib/migrieren/v1/service_services_pb.rb
@@ -25,12 +25,13 @@ module Migrieren
         #
         # gRPC failures after request validation include trailers when the request
         # reaches the transport migrator. This includes unknown database names and
-        # source/URL resolution failures; pre-migration validation InvalidArgument
-        # responses do not use this trailer path.
+        # source/database setup or reference-resolution failures; pre-migration
+        # validation InvalidArgument responses do not use this trailer path.
         # - migration-error: not_found, canceled, deadline_exceeded, invalid_config,
         #   invalid_migration, or unknown.
         # - migration-log-count: the number of migration log lines returned.
-        # - migration-stage: source or url when configuration resolution failed.
+        # - migration-stage: source for source setup or resolution failures, or url
+        #   for database setup or URL-resolution failures.
         # - migration-log-last: the last migration log line when logs were captured.
         rpc :Migrate, ::Migrieren::V1::MigrateRequest, ::Migrieren::V1::MigrateResponse
         # ApplyMigrations applies all pending up migrations for a configured
@@ -72,6 +73,11 @@ module Migrieren
         #
         # Errors use NotFound for unknown databases and Internal for configuration or
         # database inspection failures.
+        #
+        # Failures after request routing expose the same safe diagnostic trailers as
+        # Migrate when those values are available. Status does not open a migration
+        # source, so migration-stage is url when database setup or URL resolution
+        # fails.
         #
         # Status does not apply migration files, but strict request cancellation
         # depends on upstream migrate v4 context support, which is currently


### PR DESCRIPTION
## What

- Expose source and database setup provenance through existing migration diagnostics while preserving RPC shapes, status codes, and safe error bodies.
- Cover resolved setup failures for Migrate, ApplyMigrations, PlanMigrations, and Status over HTTP and gRPC; document that `url` identifies the database-setup branch.

## Why

- API clients previously received the same `invalid_config` response for resolved source and database setup failures, which left remediation ambiguous without exposing configuration values.

## Testing

- `make specs` — passed.
- `make lint` — passed.
- `make feature=features/v1/transport/http/migrate.feature tags='not @github' features` — passed (23 scenarios, 55 steps).
- `make feature=features/v1/transport/grpc/migrate.feature tags='not @github' features` — passed (27 scenarios, 66 steps).
- `make features` — passed once before the final behavior-preserving cleanup, including the GitHub fixture (139 scenarios, 359 steps); no retry was run to avoid rate-limit pressure.
- `make proto-generate`, `make proto-lint`, and `make proto-breaking` — passed.
- `make proto-stale` — generation completed, but its final whole-worktree diff check cannot pass until the intended changes are committed.
- `make sec` — not run locally because its vulnerability and Trivy databases may require network access; CI runs it.

AI-assisted-by: [Codex](https://openai.com/codex/)
