### PR TITLE
docs(agents): record the decision to reject a one-shot migration cli

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -134,6 +134,24 @@ This refreshes Go modules and updates `vendor/` (and also ensures Ruby gems for 
   explicitly decides it wants human-meaningful names in the plan response, or
   there is concrete operator evidence that version-number lookup is insufficient.
 
+### A one-shot migration CLI is not desired
+
+- Migrieren is deliberately a service. Migration execution and inspection are
+  exposed through the authenticated gRPC API and HTTP façade, not through a
+  local run-and-exit command. The only CLI subcommand is `server` (plus the
+  framework-provided `help`/`version`).
+- We considered adding a short-lived client subcommand (for example
+  `migrieren apply|migrate|status|plan -config ... -database ...`) built on the
+  go-service `AddClient`/`module.Client` batch-job wrappers, so a CI/CD deploy
+  job could run a migration without hosting the server. We decided against it:
+  if local one-shot execution is wanted, use the upstream `golang-migrate` CLI
+  directly. Migrieren does not aim to reimplement that CLI, and it intentionally
+  keeps migration execution behind the authenticated service so remote callers
+  go through token verification and the Casbin access policy.
+- Reviewers should not keep recording a one-shot/batch CLI migrate, apply,
+  status, or plan subcommand as a feature gap by default. Raise it only if the
+  project explicitly decides it wants a second, non-server execution entrypoint.
+
 ### Health probe names are reserved by convention
 
 - Health wiring uses internal probe names such as `noop` and `online`.


### PR DESCRIPTION
## What

- Add an `AGENTS.md` session note, "A one-shot migration CLI is not desired", recording that migration execution and inspection stay behind the authenticated gRPC API and HTTP façade rather than a local run-and-exit command; the only CLI subcommand remains `server` (plus the framework-provided `help`/`version`).
- Capture the rejected proposal (a short-lived `AddClient`/`module.Client` client subcommand so a CI/CD job could run a one-shot migration without hosting the server) and the reasoning, so future reviewers do not keep re-raising it as a feature gap.
- Docs-only change placed alongside the existing "not desired" notes; no code, configuration, protobuf, or generated surfaces are touched.

## Why

- A feature-gaps pass over the whole repository surfaced a one-shot CLI migration command as the single plausible gap. The maintainer decided against it: migrieren is intentionally a service, and if local one-shot execution is wanted the upstream `golang-migrate` CLI already covers it.
- Recording the decision next to the other intentional-scope notes stops the idea from being rediscovered and re-proposed on every review, and documents that keeping migration execution behind token verification and the Casbin access policy is deliberate rather than an oversight.

## Testing

- No automated checks apply to a prose-only `AGENTS.md` note, and no doc linter is wired for it in this repository.
- Verified the note's technical claims against source: `main.go` registers only the `server` subcommand; `AddClient` and `module.Client` exist in the vendored go-service and are currently unused; the authenticated token + Casbin model matches the README.
- `make lint` - not run (Go, Ruby, and protobuf sources are unchanged, so language lint is not credible coverage for this change).

AI-assisted-by: [Claude Code](https://claude.com/claude-code)
