### PR TITLE
feat(migrate): classify dirty nilversion databases correctly in status and plan

### DIFF
--- a/internal/migrate/status.go
+++ b/internal/migrate/status.go
@@ -31,7 +31,9 @@ type Status struct {
 	State StatusState
 
 	// Version is the current clean or dirty migration version. It is zero when
-	// State is StatusStateUnapplied.
+	// State is StatusStateUnapplied, and also zero when State is
+	// StatusStateDirty but no migration version was ever recorded (golang-migrate's
+	// NilVersion-dirty recovery state).
 	Version uint64
 }
 
@@ -72,12 +74,15 @@ func (m *Migrator) Status(ctx context.Context, db string) (context.Context, *Sta
 	}
 
 	status := &Status{State: StatusStateUnapplied}
-	if version >= 0 {
+	switch {
+	case dirty:
+		status.State = StatusStateDirty
+		if version >= 0 {
+			status.Version = uint64(version)
+		}
+	case version >= 0:
 		status.Version = uint64(version)
 		status.State = StatusStateClean
-		if dirty {
-			status.State = StatusStateDirty
-		}
 	}
 
 	return ctx, status, nil

--- a/test/features/step_definitions/v1/transport/migration_steps.rb
+++ b/test/features/step_definitions/v1/transport/migration_steps.rb
@@ -57,6 +57,10 @@ def empty_to_nil(value)
   value.empty? ? nil : value
 end
 
+Given('the postgres database has a dirty unapplied migration') do
+  Migrieren.pg.seed_dirty_nil_version_migration
+end
+
 Then('I should not see a completed timeout migration') do
   expect(Migrieren.pg.timeout_migration_version).to be_nil
 end

--- a/test/features/v1/transport/grpc/plan.feature
+++ b/test/features/v1/transport/grpc/plan.feature
@@ -119,6 +119,20 @@ Feature: gRPC plan API
       | version  |        3 |
       | state    | dirty    |
 
+  @clean
+  Scenario: Plan a dirty unapplied database
+    Given the postgres database has a dirty unapplied migration
+    When I request a migration plan with gRPC:
+      | database | postgres |
+    Then I should receive a migration plan from gRPC:
+      | database         | postgres |
+      | version          |        0 |
+      | state            | dirty    |
+      | latest_version   |        3 |
+      | target_version   |        0 |
+      | direction        | none     |
+      | pending_versions | 1,2,3    |
+
   Scenario: Plan missing databases
     When I request a migration plan with gRPC:
       | database | missing |

--- a/test/features/v1/transport/grpc/status.feature
+++ b/test/features/v1/transport/grpc/status.feature
@@ -54,3 +54,13 @@ Feature: gRPC status API
       | database | postgres |
       | version  |        3 |
       | state    | dirty    |
+
+  @clean
+  Scenario: Report a dirty migration status for an unapplied database
+    Given the postgres database has a dirty unapplied migration
+    When I request migration status with gRPC:
+      | database | postgres |
+    Then I should receive a migration status from gRPC:
+      | database | postgres |
+      | version  |        0 |
+      | state    | dirty    |

--- a/test/features/v1/transport/http/plan.feature
+++ b/test/features/v1/transport/http/plan.feature
@@ -119,6 +119,20 @@ Feature: HTTP plan API
       | version  |        3 |
       | state    | dirty    |
 
+  @clean
+  Scenario: Plan a dirty unapplied database
+    Given the postgres database has a dirty unapplied migration
+    When I request a migration plan with HTTP:
+      | database | postgres |
+    Then I should receive a migration plan from HTTP:
+      | database         | postgres |
+      | version          |        0 |
+      | state            | dirty    |
+      | latest_version   |        3 |
+      | target_version   |        0 |
+      | direction        | none     |
+      | pending_versions | 1,2,3    |
+
   Scenario: Plan missing databases
     When I request a migration plan with HTTP:
       | database | missing |

--- a/test/features/v1/transport/http/status.feature
+++ b/test/features/v1/transport/http/status.feature
@@ -41,3 +41,13 @@ Feature: HTTP status API
       | database    | error          | logs  | stage |
       | missing_url | invalid_config | empty | url   |
       | invalid_url | invalid_config | empty | url   |
+
+  @clean
+  Scenario: Report a dirty migration status for an unapplied database
+    Given the postgres database has a dirty unapplied migration
+    When I request migration status with HTTP:
+      | database | postgres |
+    Then I should receive a migration status from HTTP:
+      | database | postgres |
+      | version  |        0 |
+      | state    | dirty    |

--- a/test/lib/migrieren/pg.rb
+++ b/test/lib/migrieren/pg.rb
@@ -118,6 +118,22 @@ module Migrieren
     end
 
     ##
+    # Seeds the migrations table with a dirty NilVersion row.
+    #
+    # This reproduces golang-migrate's NilVersion-dirty recovery state
+    # (version -1, dirty true), which the pgx driver persists after a failed
+    # down migration that reverts the first migration. Migrieren's own API
+    # cannot produce this state (it only calls `Migrate` with version >= 1 and
+    # `ApplyMigrations`), so this helper seeds it directly with SQL, mirroring
+    # the driver's own migrations-table schema.
+    #
+    # @return [void]
+    def seed_dirty_nil_version_migration
+      @conn.exec('CREATE TABLE IF NOT EXISTS migrieren_schema_migrations (version bigint NOT NULL PRIMARY KEY, dirty boolean NOT NULL)')
+      @conn.exec('INSERT INTO migrieren_schema_migrations (version, dirty) VALUES (-1, true)')
+    end
+
+    ##
     # Returns the number of rows in the accounts fixture table.
     #
     # This is intended for post-migration assertions. If `accounts` has not been


### PR DESCRIPTION
## What

- `Status` now reports a database recorded in golang-migrate's NilVersion-dirty recovery state (version=-1, dirty=true — left behind after a failed down migration that reverts the first migration) as `state: dirty` instead of silently reporting `state: unapplied, version: 0`.
- `Plan`, which derives its up/down/dirty decision entirely from `Status.State`, now correctly short-circuits for that state instead of proposing a normal up-migration.
- No public contract change: the `StatusState` enum, proto contract, and the `Version` "zero when unapplied" behavior are unchanged; only the edge-case classification is corrected. The `Version` field's doc comment is updated to note it is also zero for this dirty-NilVersion case.

## Why

- This is exactly the recovery-inspection scenario `Status`/`Plan` exist for. Before this fix, an operator who hit that failed-down-migration recovery state saw "nothing applied" and a normal up-plan from Migrieren, while the underlying dirty guard would still block execution with `ErrInvalidMigration` at apply time — a misleading answer at the moment operators most need an accurate one.
- Blast radius was bounded (mutation was always blocked by the engine's dirty guard), so this was a misleading-inspection defect rather than a data-safety one, but it is still a wrong answer from a read-only API whose entire purpose is accurate inspection.

## Testing

- `make features` (grpc/status.feature, grpc/plan.feature, http/status.feature, http/plan.feature) - passed (4 new scenarios added; observed red against the pre-fix code, green after the fix)
- `make features` (full suite) - 142/143 scenarios passed; the 1 failure is the pre-existing, network-dependent `@github` migration-source example row, confirmed unrelated by rerunning it in isolation twice (passed both times)
- `make specs` - passed (no Go tests exist for `internal/migrate` by repo convention; this package's coverage is the Ruby/Cucumber harness)
- `make go-lint package=internal/migrate` - passed
- `make ruby-lint` - passed
- `make sec` - passed (only a pre-existing, unrelated `golang.org/x/crypto` advisory that this change does not call into)
- Since this state cannot be produced through Migrieren's own API (it only calls `Migrate` with version >= 1, or `ApplyMigrations`), the new scenarios seed the `migrieren_schema_migrations` row directly via SQL through a new `Migrieren::PG#seed_dirty_nil_version_migration` test helper, using the same table DDL the pgx driver itself uses.

AI-assisted-by: [Claude Code](https://claude.com/claude-code)
