### PR TITLE
docs(readme): list canceled and deadline-exceeded errors for the status rpc

### DIFF
--- a/api/migrieren/v1/service.proto
+++ b/api/migrieren/v1/service.proto
@@ -249,8 +249,9 @@ service Service {
   // Status reports the current migration version state for a configured
   // database.
   //
-  // Errors use NotFound for unknown databases and Internal for configuration or
-  // database inspection failures.
+  // Errors use NotFound for unknown databases, Canceled/DeadlineExceeded for
+  // stopped requests, and Internal for configuration or database inspection
+  // failures.
   //
   // Failures after request routing expose the same safe diagnostic trailers as
   // Migrate when those values are available. Status does not open a migration

--- a/api/migrieren/v1/service_grpc.pb.go
+++ b/api/migrieren/v1/service_grpc.pb.go
@@ -87,8 +87,9 @@ type ServiceClient interface {
 	// Status reports the current migration version state for a configured
 	// database.
 	//
-	// Errors use NotFound for unknown databases and Internal for configuration or
-	// database inspection failures.
+	// Errors use NotFound for unknown databases, Canceled/DeadlineExceeded for
+	// stopped requests, and Internal for configuration or database inspection
+	// failures.
 	//
 	// Failures after request routing expose the same safe diagnostic trailers as
 	// Migrate when those values are available. Status does not open a migration
@@ -225,8 +226,9 @@ type ServiceServer interface {
 	// Status reports the current migration version state for a configured
 	// database.
 	//
-	// Errors use NotFound for unknown databases and Internal for configuration or
-	// database inspection failures.
+	// Errors use NotFound for unknown databases, Canceled/DeadlineExceeded for
+	// stopped requests, and Internal for configuration or database inspection
+	// failures.
 	//
 	// Failures after request routing expose the same safe diagnostic trailers as
 	// Migrate when those values are available. Status does not open a migration

--- a/test/lib/migrieren/v1/service_services_pb.rb
+++ b/test/lib/migrieren/v1/service_services_pb.rb
@@ -71,8 +71,9 @@ module Migrieren
         # Status reports the current migration version state for a configured
         # database.
         #
-        # Errors use NotFound for unknown databases and Internal for configuration or
-        # database inspection failures.
+        # Errors use NotFound for unknown databases, Canceled/DeadlineExceeded for
+        # stopped requests, and Internal for configuration or database inspection
+        # failures.
         #
         # Failures after request routing expose the same safe diagnostic trailers as
         # Migrate when those values are available. Status does not open a migration


### PR DESCRIPTION
## What

- The `Status` RPC contract comment in `api/migrieren/v1/service.proto` now lists `Canceled`/`DeadlineExceeded` for stopped requests alongside the existing `NotFound` and `Internal` codes, matching the `Migrate`, `ApplyMigrations`, and `PlanMigrations` comments that already document them.
- Regenerated the Go and Ruby gRPC stubs so their embedded doc comments track the `.proto`. This is comment-only: no message, field, RPC signature, or wire change, and the existing note about incomplete upstream migrate v4 context support on `Status` is preserved.

## Why

- `Status` reachably returns `Canceled`/`DeadlineExceeded` on gRPC (and `499`/`504` on the HTTP façade): the service checks the request context before and after the database version call in `internal/migrate/status.go`, `migrationError` maps context cancellation and deadline to `ErrMigrationCanceled`/`ErrMigrationDeadlineExceeded`, and the transport `error()` mappers convert those to the matching status codes.
- Because the per-RPC comment omitted them, `Status` was the only one of the five RPCs whose documented error contract was incomplete, so a client author building status-code handling from that comment would miss the cancel and timeout branches. The README's error mapping is a single global table that already covered every RPC, so no README change was needed.

## Testing

- `make lint` - passed (Go 0 issues, Ruby 27 files no offenses, proto lint clean)
- `make proto-generate` - passed; re-running produced no further changes, confirming the generated stubs are in sync with the `.proto`
- `make proto-lint` - passed
- `go build -mod=vendor ./...` - passed
- CI additionally runs `make proto-breaking` (comment-only change, expected non-breaking) and `make proto-stale` (validates committed generated output matches the `.proto`).

AI-assisted-by: [Claude Code](https://claude.com/claude-code)
