### PR TITLE
docs(readme): clarify migration operations and client contracts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -68,19 +68,6 @@ This refreshes Go modules and updates `vendor/` (and also ensures Ruby gems for 
   upstream behavior if there is current evidence, but should not recommend
   moving this coverage out of the default `make features` gate by default.
 
-### GitHub source timeout behavior is an accepted library shortcoming
-
-- The wired `github://` migration source uses the upstream
-  `golang-migrate/migrate` GitHub source driver through `source.Open(...)`.
-- That upstream path does not expose this service's request context or a clean
-  per-request timeout hook without duplicating the driver's URL parsing and
-  client construction locally.
-- Do not keep resurfacing the lack of a repository-owned GitHub source timeout
-  wrapper as a reliability gap by default. Treat it as an accepted upstream
-  library shortcoming unless there is concrete production evidence, a simpler
-  upstream-supported hook becomes available, or the project explicitly decides
-  to own a local GitHub source wrapper.
-
 ### pgx advisory lock timeout behavior is an accepted library shortcoming
 
 - The wired Postgres migration path uses the upstream `golang-migrate/migrate`

--- a/README.md
+++ b/README.md
@@ -156,6 +156,11 @@ transport:
     timeout: 5s
 ```
 
+`health.duration` sets how often the service evaluates its noop, online, and
+per-database health registrations. `health.timeout` bounds the online check and
+each database target's source validation and database ping. Migration request
+timeouts are configured separately by the transport and database URL options.
+
 ### 🗄️ Migration database entries
 
 `migrate.databases` must contain at least one entry. Each entry must have a
@@ -166,9 +171,11 @@ unique `name` and all of these fields:
 - `url`: how to resolve the database connection URL.
 
 `migrate.logs` is optional. `migrate.logs.max` bounds how many migration log
-lines each `Migrate`/`ApplyMigrations` response returns (default 100). When the
-limit is exceeded, the oldest lines are dropped and the first returned entry is a
-`migration logs truncated (showing last N of M)` marker.
+lines each `Migrate`/`ApplyMigrations` response returns. Omitting it or setting
+it to `0` selects the default of 100; only positive values set a custom cap, and
+there is no value that disables returned logs. Negative values are invalid.
+When the limit is exceeded, the oldest lines are dropped and the first returned
+entry is a `migration logs truncated (showing last N of M)` marker.
 
 In the checked-in test setup, the referenced secret files contain the actual values consumed by the migrator:
 
@@ -195,6 +202,25 @@ migrate:
 
 ultimately migrates Postgres using the `file://migrations` source and the `pgx5://...` database URL resolved from those files.
 
+### 🐙 GitHub migration sources
+
+GitHub sources use this URL shape:
+
+```text
+github://[user:personal-access-token@]owner/repository[/path][#ref]
+```
+
+- Without user information, the repository is read without authentication.
+- For a private repository, place the personal access token in the URL password;
+  the user name is ignored.
+- The optional path selects a migration directory within the repository.
+- The optional fragment selects a branch, tag, or commit SHA. When omitted,
+  GitHub's default branch is used.
+
+The migration directory is listed when the source opens. Keep credential-bearing
+URLs out of checked-in YAML: set `source` to a secret-backed `file:` reference or
+to an `env:` reference whose value is the complete `github://` URL.
+
 ### 🐘 Postgres URL options
 
 Postgres targets use `pgx5://...` URLs. In addition to normal Postgres
@@ -205,8 +231,10 @@ parameters:
   default is used.
 - `x-migrations-table-quoted`: boolean. When `true`, `x-migrations-table` must
   include surrounding double quotes.
-- `x-statement-timeout`: statement timeout in milliseconds. Request deadlines
-  can lower this timeout for an individual migration or health check.
+- `x-statement-timeout`: statement timeout in milliseconds for migration
+  operations. A migration request deadline can lower this timeout. Health checks
+  instead use `health.timeout` to bound `PingContext` and do not use this
+  statement timeout.
 - `x-multi-statement`: boolean enabling multi-statement migrations.
 - `x-multi-statement-max-size`: byte limit for multi-statement migrations.
   Empty or non-positive values use the upstream driver default.
@@ -422,8 +450,8 @@ target_version: 1
 > step-based up/down, rollback-by-step, all-down, or version-zero migration
 > APIs. Use `Migrate` for an explicit target version and `ApplyMigrations` for
 > latest. An explicit plan reports the same safe migration failure as `Migrate`
-> when the current database state is dirty or its requested target is absent
-> from the source.
+> when the current database state is dirty, its requested target is absent from
+> the source, or a recorded current version is absent from the source.
 
 ### 🔎 Migration status
 
@@ -438,8 +466,10 @@ Response:
 
 - `meta`: request metadata emitted by the service runtime.
 - `status.database`: echoed database name.
-- `status.version`: current clean or dirty migration version. When
-  `status.state` is `MIGRATION_STATE_UNAPPLIED`, this is `0`.
+- `status.version`: current clean or dirty migration version. It is `0` when
+  `status.state` is `MIGRATION_STATE_UNAPPLIED`, and can also be `0` with
+  `MIGRATION_STATE_DIRTY` when migration metadata records a dirty recovery state
+  without a version. Always use `status.state` to distinguish those cases.
 - `status.state`: one of `MIGRATION_STATE_UNAPPLIED`,
   `MIGRATION_STATE_CLEAN`, or `MIGRATION_STATE_DIRTY`.
 
@@ -491,11 +521,27 @@ The HTTP RPC façade exposes the same operation at:
 - `POST /migrieren.v1.Service/Status`
 - `POST /migrieren.v1.Service/ListDatabases`
 
+The checked-in test config requires a route-scoped Bearer value for application
+RPCs. After `make dep`, run the examples below from `test/` and define this
+helper once; it uses the throwaway test signing key to mint a header for the
+exact route passed to it without placing the token in curl's process arguments:
+
+```sh
+http_authorization() {
+  bundle exec ruby -Ilib -rnonnative -rmigrieren \
+    -e 'puts "Authorization: #{Migrieren.http_authorization(ARGV.fetch(0))}"' "$1"
+}
+```
+
+If your own config omits token verification and access control, the
+`Authorization` header is unnecessary.
+
 Example:
 
 ```http
 POST http://localhost:11000/migrieren.v1.Service/Migrate
 Content-Type: application/json
+Authorization: Bearer <route-scoped-token>
 
 {
   "database": "postgres",
@@ -506,40 +552,50 @@ Content-Type: application/json
 Copy-paste request against the local HTTP façade:
 
 ```sh
-curl -sS -X POST http://localhost:11000/migrieren.v1.Service/Migrate \
+http_authorization '/migrieren.v1.Service/Migrate' |
+  curl -sS -X POST http://localhost:11000/migrieren.v1.Service/Migrate \
   -H 'Content-Type: application/json' \
+  --header @- \
   -d '{"database":"postgres","version":1}'
 ```
 
 Copy-paste apply-all request against the local HTTP façade:
 
 ```sh
-curl -sS -X POST http://localhost:11000/migrieren.v1.Service/ApplyMigrations \
+http_authorization '/migrieren.v1.Service/ApplyMigrations' |
+  curl -sS -X POST http://localhost:11000/migrieren.v1.Service/ApplyMigrations \
   -H 'Content-Type: application/json' \
+  --header @- \
   -d '{"database":"postgres"}'
 ```
 
 Copy-paste plan request against the local HTTP façade:
 
 ```sh
-curl -sS -X POST http://localhost:11000/migrieren.v1.Service/PlanMigrations \
+http_authorization '/migrieren.v1.Service/PlanMigrations' |
+  curl -sS -X POST http://localhost:11000/migrieren.v1.Service/PlanMigrations \
   -H 'Content-Type: application/json' \
+  --header @- \
   -d '{"database":"postgres","target_version":1}'
 ```
 
 Copy-paste status request against the local HTTP façade:
 
 ```sh
-curl -sS -X POST http://localhost:11000/migrieren.v1.Service/Status \
+http_authorization '/migrieren.v1.Service/Status' |
+  curl -sS -X POST http://localhost:11000/migrieren.v1.Service/Status \
   -H 'Content-Type: application/json' \
+  --header @- \
   -d '{"database":"postgres"}'
 ```
 
 Copy-paste database discovery request against the local HTTP façade:
 
 ```sh
-curl -sS -X POST http://localhost:11000/migrieren.v1.Service/ListDatabases \
+http_authorization '/migrieren.v1.Service/ListDatabases' |
+  curl -sS -X POST http://localhost:11000/migrieren.v1.Service/ListDatabases \
   -H 'Content-Type: application/json' \
+  --header @- \
   -d '{}'
 ```
 
@@ -547,6 +603,12 @@ curl -sS -X POST http://localhost:11000/migrieren.v1.Service/ListDatabases \
 
 Transport behavior is intentionally simple:
 
+- Missing or invalid credentials when token verification is enabled:
+  - gRPC: `Unauthenticated`
+  - HTTP: `401`
+- Authenticated subject denied by the access policy:
+  - gRPC: `PermissionDenied`
+  - HTTP: `403`
 - Migration version outside the supported range:
   - gRPC: `InvalidArgument`
   - HTTP: `400`
@@ -601,6 +663,19 @@ When running with the shared service runtime, Migrieren exposes:
 - HTTP metrics:
   - `/migrieren/metrics`
 - gRPC health checks for `migrieren.v1.Service`
+
+The probe contracts are deliberately different:
+
+| Surface | Checks observed | Operational meaning |
+| --- | --- | --- |
+| HTTP `/migrieren/livez` | `noop` | Process liveness only. |
+| HTTP `/migrieren/readyz` | `noop` | Process readiness only; it does not gate on migration dependencies. |
+| HTTP `/migrieren/healthz` | `online` and every configured database target | Public connectivity plus source validation and database reachability. |
+| gRPC health for `migrieren.v1.Service` | `noop` | Service-process health independent of migration dependencies. |
+
+The shared `online` check uses its default public connectivity endpoints. Use
+`healthz` for dependency health, not as a liveness probe that should remain
+stable during an egress or database outage.
 
 There is an important detail in the checked-in test config:
 

--- a/api/migrieren/v1/service.pb.go
+++ b/api/migrieren/v1/service.pb.go
@@ -32,7 +32,8 @@ const (
 	MigrationState_MIGRATION_STATE_UNAPPLIED MigrationState = 1
 	// MIGRATION_STATE_CLEAN means a non-dirty migration version is recorded.
 	MigrationState_MIGRATION_STATE_CLEAN MigrationState = 2
-	// MIGRATION_STATE_DIRTY means the recorded migration version is dirty.
+	// MIGRATION_STATE_DIRTY means migration metadata is dirty. Its associated
+	// version can be zero when the dirty state has no recorded version.
 	MigrationState_MIGRATION_STATE_DIRTY MigrationState = 3
 )
 
@@ -427,7 +428,9 @@ type MigrationStatus struct {
 	// version is the current clean or dirty migration version.
 	//
 	// When state is MIGRATION_STATE_UNAPPLIED, version is zero and no migration
-	// version has been recorded yet.
+	// version has been recorded yet. Version can also be zero when state is
+	// MIGRATION_STATE_DIRTY and the dirty metadata has no recorded version, so
+	// callers must inspect state rather than classifying zero by itself.
 	Version uint64 `protobuf:"varint,2,opt,name=version,proto3" json:"version,omitempty"`
 	// state reports whether the migration version is unapplied, clean, or dirty.
 	State         MigrationState `protobuf:"varint,3,opt,name=state,proto3,enum=migrieren.v1.MigrationState" json:"state,omitempty"`
@@ -588,7 +591,10 @@ type PlanMigrationsRequest struct {
 	// target_version is an optional migration version to preview. When omitted,
 	// the service previews convergence to the latest available up migration.
 	// When supplied, it must be greater than zero and fit within the
-	// server-supported signed integer range.
+	// server-supported signed integer range. The database must not be dirty, the
+	// target must exist in the source, and any recorded current version must also
+	// exist in the source; violations are migration-inspection failures rather
+	// than InvalidArgument errors.
 	TargetVersion *uint64 `protobuf:"varint,2,opt,name=target_version,json=targetVersion,proto3,oneof" json:"target_version,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache

--- a/api/migrieren/v1/service.proto
+++ b/api/migrieren/v1/service.proto
@@ -69,7 +69,8 @@ enum MigrationState {
   // MIGRATION_STATE_CLEAN means a non-dirty migration version is recorded.
   MIGRATION_STATE_CLEAN = 2;
 
-  // MIGRATION_STATE_DIRTY means the recorded migration version is dirty.
+  // MIGRATION_STATE_DIRTY means migration metadata is dirty. Its associated
+  // version can be zero when the dirty state has no recorded version.
   MIGRATION_STATE_DIRTY = 3;
 }
 
@@ -81,7 +82,9 @@ message MigrationStatus {
   // version is the current clean or dirty migration version.
   //
   // When state is MIGRATION_STATE_UNAPPLIED, version is zero and no migration
-  // version has been recorded yet.
+  // version has been recorded yet. Version can also be zero when state is
+  // MIGRATION_STATE_DIRTY and the dirty metadata has no recorded version, so
+  // callers must inspect state rather than classifying zero by itself.
   uint64 version = 2;
 
   // state reports whether the migration version is unapplied, clean, or dirty.
@@ -142,7 +145,10 @@ message PlanMigrationsRequest {
   // target_version is an optional migration version to preview. When omitted,
   // the service previews convergence to the latest available up migration.
   // When supplied, it must be greater than zero and fit within the
-  // server-supported signed integer range.
+  // server-supported signed integer range. The database must not be dirty, the
+  // target must exist in the source, and any recorded current version must also
+  // exist in the source; violations are migration-inspection failures rather
+  // than InvalidArgument errors.
   optional uint64 target_version = 2;
 }
 
@@ -240,6 +246,10 @@ service Service {
   // Failures after request routing expose the same safe diagnostic trailers as
   // Migrate, including migration-error, migration-log-count, migration-stage,
   // and migration-log-last when those values are available.
+  //
+  // An explicit target requires a non-dirty database state and source
+  // membership for both the target and any recorded current version. Violations
+  // are reported as Internal migration-inspection failures, not InvalidArgument.
   //
   // PlanMigrations opens the configured migration source to discover available
   // versions, but it does not read migration bodies or expose configured source

--- a/api/migrieren/v1/service_grpc.pb.go
+++ b/api/migrieren/v1/service_grpc.pb.go
@@ -80,6 +80,10 @@ type ServiceClient interface {
 	// Migrate, including migration-error, migration-log-count, migration-stage,
 	// and migration-log-last when those values are available.
 	//
+	// An explicit target requires a non-dirty database state and source
+	// membership for both the target and any recorded current version. Violations
+	// are reported as Internal migration-inspection failures, not InvalidArgument.
+	//
 	// PlanMigrations opens the configured migration source to discover available
 	// versions, but it does not read migration bodies or expose configured source
 	// strings, database URL strings, or resolved secret values.
@@ -218,6 +222,10 @@ type ServiceServer interface {
 	// Failures after request routing expose the same safe diagnostic trailers as
 	// Migrate, including migration-error, migration-log-count, migration-stage,
 	// and migration-log-last when those values are available.
+	//
+	// An explicit target requires a non-dirty database state and source
+	// membership for both the target and any recorded current version. Violations
+	// are reported as Internal migration-inspection failures, not InvalidArgument.
 	//
 	// PlanMigrations opens the configured migration source to discover available
 	// versions, but it does not read migration bodies or expose configured source

--- a/internal/api/v1/migrate/doc.go
+++ b/internal/api/v1/migrate/doc.go
@@ -2,9 +2,9 @@
 // transports.
 //
 // The package accepts generated v1 request messages and returns generated v1
-// response messages. It owns versioned API response construction, public request
-// validation, configured database lookup, source/URL resolution, and delegation
-// to the core migration engine.
+// response messages. It owns versioned API response construction and public
+// request validation, then delegates configured database lookup, source/URL
+// resolution, and core migration work to the API-facing migrate adapter.
 //
 // Transport packages remain responsible for registration, safe status-code
 // mapping, and exposing diagnostics as the correct transport metadata

--- a/internal/migrate/source/doc.go
+++ b/internal/migrate/source/doc.go
@@ -2,5 +2,5 @@
 //
 // It registers the supported golang-migrate source drivers and provides a
 // bounded health-check path that avoids opening GitHub sources, because the
-// upstream GitHub driver does not expose a request-scoped timeout hook.
+// registered GitHub driver's Open method is not request-scoped.
 package source

--- a/internal/migrate/source/source.go
+++ b/internal/migrate/source/source.go
@@ -21,9 +21,9 @@ type VersionSource interface {
 // Check validates that sourceURL can be used as a migration source without
 // making unbounded external dependency calls.
 //
-// GitHub sources are parsed but not opened here, because the upstream source
-// driver does not expose a request-scoped timeout hook. The actual GitHub source
-// is opened later during migration execution.
+// GitHub sources are parsed but not opened here, because the registered GitHub
+// driver's Open method is not request-scoped. The actual GitHub source is opened
+// later during migration execution.
 func Check(ctx context.Context, sourceURL string) error {
 	if err := ctx.Err(); err != nil {
 		return err

--- a/test/lib/migrieren/v1/http.rb
+++ b/test/lib/migrieren/v1/http.rb
@@ -11,6 +11,13 @@ module Migrieren
     # Under the hood it delegates request execution to `Nonnative::HTTPClient`,
     # and exposes small convenience methods for the endpoints used in tests.
     #
+    # Endpoint helpers normally return `RestClient::Response` objects for
+    # successful and non-2xx HTTP responses, so callers inspect `code`, `body`,
+    # and `headers` directly. Passing `raw_response: true` returns a
+    # `RestClient::RawResponse` instead. Timeouts, broken connections, and other
+    # transport failures propagate as RestClient or system exceptions rather
+    # than being converted into responses.
+    #
     # The service is expected to be reachable at the base URL provided when the
     # client is constructed (see `Migrieren::V1.server_http`).
     class HTTP < Nonnative::HTTPClient
@@ -26,7 +33,8 @@ module Migrieren
       # @param database [String] logical database name as configured in the service
       # @param version [Integer] target migration version (encoded as JSON number)
       # @param opts [Hash] optional request options passed through to `post`
-      # @return [Object] whatever `Nonnative::HTTPClient#post` returns (typically a response wrapper)
+      # @return [RestClient::Response, RestClient::RawResponse] the HTTP response;
+      #   RawResponse is returned when opts enables raw_response
       def migrate(database, version, opts = {})
         post('/migrieren.v1.Service/Migrate', { database:, version: }.to_json, opts)
       end
@@ -42,7 +50,8 @@ module Migrieren
       #
       # @param database [String] logical database name as configured in the service
       # @param opts [Hash] optional request options passed through to `post`
-      # @return [Object] whatever `Nonnative::HTTPClient#post` returns (typically a response wrapper)
+      # @return [RestClient::Response, RestClient::RawResponse] the HTTP response;
+      #   RawResponse is returned when opts enables raw_response
       def apply_migrations(database, opts = {})
         post('/migrieren.v1.Service/ApplyMigrations', { database: }.to_json, opts)
       end
@@ -60,7 +69,8 @@ module Migrieren
       # @param opts [Hash] optional request options passed through to `post`
       # @param target_version [Integer, nil] optional explicit migration version
       #   to preview; when nil, the request preserves latest-up planning
-      # @return [Object] whatever `Nonnative::HTTPClient#post` returns (typically a response wrapper)
+      # @return [RestClient::Response, RestClient::RawResponse] the HTTP response;
+      #   RawResponse is returned when opts enables raw_response
       def plan_migrations(database, opts = {}, target_version: nil)
         payload = { database: }
         payload[:target_version] = target_version unless target_version.nil?
@@ -79,7 +89,8 @@ module Migrieren
       #
       # @param database [String] logical database name as configured in the service
       # @param opts [Hash] optional request options passed through to `post`
-      # @return [Object] whatever `Nonnative::HTTPClient#post` returns (typically a response wrapper)
+      # @return [RestClient::Response, RestClient::RawResponse] the HTTP response;
+      #   RawResponse is returned when opts enables raw_response
       def status(database, opts = {})
         post('/migrieren.v1.Service/Status', { database: }.to_json, opts)
       end
@@ -91,7 +102,8 @@ module Migrieren
       # `POST /migrieren.v1.Service/ListDatabases`
       #
       # @param opts [Hash] optional request options passed through to `post`
-      # @return [Object] whatever `Nonnative::HTTPClient#post` returns (typically a response wrapper)
+      # @return [RestClient::Response, RestClient::RawResponse] the HTTP response;
+      #   RawResponse is returned when opts enables raw_response
       def list_databases(opts = {})
         post('/migrieren.v1.Service/ListDatabases', {}.to_json, opts)
       end
@@ -110,7 +122,8 @@ module Migrieren
       # @param pathname [String] the HTTP RPC path
       # @param payload [String] the JSON request body
       # @param opts [Hash] request options passed to `Nonnative::HTTPClient#post`
-      # @return [Object] the base client's response
+      # @return [RestClient::Response, RestClient::RawResponse] the base client's
+      #   response; RawResponse is returned when opts enables raw_response
       def post(pathname, payload, opts = {})
         super(pathname, payload, Migrieren.authorize_http(pathname, opts))
       end

--- a/test/lib/migrieren/v1/service_services_pb.rb
+++ b/test/lib/migrieren/v1/service_services_pb.rb
@@ -64,6 +64,10 @@ module Migrieren
         # Migrate, including migration-error, migration-log-count, migration-stage,
         # and migration-log-last when those values are available.
         #
+        # An explicit target requires a non-dirty database state and source
+        # membership for both the target and any recorded current version. Violations
+        # are reported as Internal migration-inspection failures, not InvalidArgument.
+        #
         # PlanMigrations opens the configured migration source to discover available
         # versions, but it does not read migration bodies or expose configured source
         # strings, database URL strings, or resolved secret values.


### PR DESCRIPTION
## What

- Correct operator guidance for health probes and timeouts, migration log limits, GitHub source URLs, authenticated HTTP requests, and transport error mappings.
- Clarify dirty version-zero status and explicit migration-plan preconditions in the protobuf contract, then regenerate the Go and Ruby client comments without changing the wire schema.
- Correct API/source ownership documentation, document the Ruby HTTP harness response contract, and remove obsolete guidance that attributed the repository-owned GitHub driver to upstream code.
- Keep route-scoped test bearer values out of curl process arguments by passing generated headers through standard input.

## Why

- The previous documentation could make advertised local requests fail with 401 responses, lead operators to choose the wrong health probe or timeout setting, and leave API consumers unaware of valid dirty-status and plan-failure states.
- Accurate ownership and generated-client documentation helps maintainers change the correct layer while preserving the existing service, compatibility, and security boundaries.

## Testing

- `make lint` - passed with 0 Go issues, 27 Ruby files clean, and protobuf lint clean.
- `make specs` - passed; all 19 Go packages compiled and the repository reported 0 package tests.
- `make proto-breaking` - passed against the remote master baseline.
- `make proto-generate` - passed and a second generation produced an identical diff hash.
- `make feature=features/v1/transport/http/auth.feature features` - passed, 4 scenarios and 8 steps.
- `git diff --check` - passed.
- CI will additionally run the full feature, security, benchmark, generated-staleness, analysis, and coverage checks.

AI-assisted-by: [Codex](https://openai.com/codex/)
