### PR TITLE
feat(deps): upgraded github.com/alexfalkowski/go-service/v2 to v2.663.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.26.0
 
 require (
 	github.com/alexfalkowski/go-health/v2 v2.35.0
-	github.com/alexfalkowski/go-service/v2 v2.662.0
+	github.com/alexfalkowski/go-service/v2 v2.663.0
 	github.com/golang-migrate/migrate/v4 v4.19.1
 	github.com/google/go-github/v89 v89.0.0
 	github.com/jackc/pgx/v5 v5.10.0

--- a/go.sum
+++ b/go.sum
@@ -20,8 +20,8 @@ github.com/aead/cmac v0.0.0-20160719120800-7af84192f0b1 h1:+JkXLHME8vLJafGhOH4ao
 github.com/aead/cmac v0.0.0-20160719120800-7af84192f0b1/go.mod h1:nuudZmJhzWtx2212z+pkuy7B6nkBqa+xwNXZHL1j8cg=
 github.com/alexfalkowski/go-health/v2 v2.35.0 h1:Fw2VcXuzFFu3nNLZ899KwNH7MgqttJ1i9cQDwPvk1/E=
 github.com/alexfalkowski/go-health/v2 v2.35.0/go.mod h1:JgnHd/ajgMgxqZ5RNU3gEohFyi6qS5SJ5gXHN2YYDe4=
-github.com/alexfalkowski/go-service/v2 v2.662.0 h1:7pSv7Ql+kb3qMdm9wj+MzAHHFUOx4uc08LdeeSCy230=
-github.com/alexfalkowski/go-service/v2 v2.662.0/go.mod h1:agLjz94+/BWqIOcUXJCHYcU8dQtzDDlnt+ma6TFvMbI=
+github.com/alexfalkowski/go-service/v2 v2.663.0 h1:3/oamxkDpPKzXT86Od1QTYPeSbY8xAhZhHtfXDLpPWI=
+github.com/alexfalkowski/go-service/v2 v2.663.0/go.mod h1:EG7wsMPc1XAO4X+jLkyJaQVsJZuGbDs9a32T/r8twgw=
 github.com/alexfalkowski/go-sync v1.30.0 h1:DcNUSV9UgZGIkxE9SJiQcUgdmd1AANK+qeoQmSJsf4k=
 github.com/alexfalkowski/go-sync v1.30.0/go.mod h1:IzEbtMNtoLHdIfoO6Z+f7azto4wjLuj6ZgAOrpKLZbY=
 github.com/arl/statsviz v0.8.1 h1:9Ns7GBWCPWn46M/KfqZ5BqRxU578e/MV7/DOwpt2Sd8=


### PR DESCRIPTION
https://github.com/alexfalkowski/go-service/releases/tag/v2.663.0
