### PR TITLE
test(feature): cover migration behavior under proxy faults

### DIFF
--- a/test/features/health/transport/http/observability.feature
+++ b/test/features/health/transport/http/observability.feature
@@ -12,6 +12,16 @@ Feature: Observability
     Given I set the proxy for service 'postgres' to 'timeout'
     Then I should see "postgres" as unhealthy
 
+  @reset
+  Scenario: Health with a reset Postgres dependency
+    Given I set the proxy for service 'postgres' to 'reset_peer'
+    Then I should see "postgres" as unhealthy
+
+  @reset
+  Scenario: Health with a slow but live Postgres dependency
+    Given I set the proxy for service 'postgres' to 'delay'
+    Then I should see "postgres" as unhealthy
+
   Scenario: Liveness with HTTP
     When the system requests the "liveness" with HTTP
     Then the system should respond with a healthy status with HTTP

--- a/test/features/v1/transport/grpc/migrate.feature
+++ b/test/features/v1/transport/grpc/migrate.feature
@@ -123,3 +123,23 @@ Feature: gRPC migrate API
       | database | postgres |
       | version  |        1 |
     Then I should receive a stopped deadline migration from gRPC
+
+  @reset
+  Scenario: Recover public migrations after Postgres resets the connection
+    Given I set the proxy for service 'postgres' to 'reset_peer'
+    And I should see "postgres" as unhealthy
+    When I request to migrate with gRPC:
+      | database | postgres |
+      | version  |        1 |
+    Then I should receive an invalid migration from gRPC
+    And I should receive failure diagnostics from gRPC:
+      | error | invalid_config |
+      | logs  | empty          |
+      | stage | url            |
+    And I should reset the proxy for service 'postgres'
+    When I request to migrate with gRPC:
+      | database | postgres |
+      | version  |        1 |
+    Then I should receive a successful migration from gRPC:
+      | database | postgres |
+      | version  |        1 |

--- a/test/features/v1/transport/grpc/plan.feature
+++ b/test/features/v1/transport/grpc/plan.feature
@@ -15,6 +15,20 @@ Feature: gRPC plan API
       | direction        | up        |
       | pending_versions | 1..40     |
 
+  @clean @reset
+  Scenario: Plan all pending migrations over a fragmented connection
+    Given I set the proxy for service 'postgres' to 'slicer'
+    When I request a migration plan with gRPC:
+      | database | logs |
+    Then I should receive a migration plan from gRPC:
+      | database         | logs      |
+      | version          | 0         |
+      | state            | unapplied |
+      | latest_version   | 40        |
+      | target_version   | 40        |
+      | direction        | up        |
+      | pending_versions | 1..40     |
+
   @clean
   Scenario: Plan migrations when already current
     When I request to apply migrations with gRPC:

--- a/test/features/v1/transport/grpc/status.feature
+++ b/test/features/v1/transport/grpc/status.feature
@@ -64,3 +64,15 @@ Feature: gRPC status API
       | database | postgres |
       | version  |        0 |
       | state    | dirty    |
+
+  @reset
+  Scenario Outline: Reject <fault> Postgres responses
+    Given I set the proxy for service 'postgres' to '<fault>'
+    When I request migration status with gRPC:
+      | database | postgres |
+    Then I should receive an invalid migration from gRPC
+
+    Examples:
+      | fault        |
+      | invalid_data |
+      | limit_data   |

--- a/test/features/v1/transport/http/migrate.feature
+++ b/test/features/v1/transport/http/migrate.feature
@@ -99,3 +99,23 @@ Feature: HTTP migrate API
       | database | postgres |
       | version  |        1 |
     Then I should receive a timed out migration from HTTP
+
+  @reset
+  Scenario: Recover public migrations after Postgres resets the connection
+    Given I set the proxy for service 'postgres' to 'reset_peer'
+    And I should see "postgres" as unhealthy
+    When I request to migrate with HTTP:
+      | database | postgres |
+      | version  |        1 |
+    Then I should receive an invalid migration from HTTP
+    And I should receive failure diagnostics from HTTP:
+      | error | invalid_config |
+      | logs  | empty          |
+      | stage | url            |
+    And I should reset the proxy for service 'postgres'
+    When I request to migrate with HTTP:
+      | database | postgres |
+      | version  |        1 |
+    Then I should receive a successful migration from HTTP:
+      | database | postgres |
+      | version  |        1 |

--- a/test/features/v1/transport/http/plan.feature
+++ b/test/features/v1/transport/http/plan.feature
@@ -15,6 +15,20 @@ Feature: HTTP plan API
       | direction        | up        |
       | pending_versions | 1..40     |
 
+  @clean @reset
+  Scenario: Plan all pending migrations over a fragmented connection
+    Given I set the proxy for service 'postgres' to 'slicer'
+    When I request a migration plan with HTTP:
+      | database | logs |
+    Then I should receive a migration plan from HTTP:
+      | database         | logs      |
+      | version          | 0         |
+      | state            | unapplied |
+      | latest_version   | 40        |
+      | target_version   | 40        |
+      | direction        | up        |
+      | pending_versions | 1..40     |
+
   @clean
   Scenario: Plan migrations when already current
     When I request to apply migrations with HTTP:

--- a/test/features/v1/transport/http/status.feature
+++ b/test/features/v1/transport/http/status.feature
@@ -51,3 +51,15 @@ Feature: HTTP status API
       | database | postgres |
       | version  |        0 |
       | state    | dirty    |
+
+  @reset
+  Scenario Outline: Reject <fault> Postgres responses
+    Given I set the proxy for service 'postgres' to '<fault>'
+    When I request migration status with HTTP:
+      | database | postgres |
+    Then I should receive an invalid migration from HTTP
+
+    Examples:
+      | fault        |
+      | invalid_data |
+      | limit_data   |

--- a/test/nonnative.yml
+++ b/test/nonnative.yml
@@ -40,3 +40,6 @@ services:
       wait: 1
       options:
         delay: 2
+        bytes: 1
+        slice_size: 32
+        slice_delay: 0.01


### PR DESCRIPTION
## What

- Extend HTTP and gRPC feature coverage for Postgres connection resets, malformed and truncated responses, and fragmented migration-plan responses.
- Exercise health behavior for reset and delayed Postgres dependencies, with proxy settings that support byte limits and response slicing.

## Why

- Protect migration and health API behavior when a Postgres dependency is slow, disconnects, or returns incomplete data, while keeping the HTTP and gRPC contracts covered consistently.

## Testing

- `make -C test lint` - passed
- `make features` - passed (153 scenarios, 409 steps), including the added HTTP and gRPC proxy-fault scenarios.
- `make sec` - passed (no reachable Go vulnerabilities; Trivy reported no dependency vulnerabilities or secrets).

AI-assisted-by: [Codex](https://openai.com/codex/)
