### PR TITLE
test(feature): accept timeout errors from HTTP migration client

### DIFF
--- a/test/features/step_definitions/v1/transport/http/migrate_steps.rb
+++ b/test/features/step_definitions/v1/transport/http/migrate_steps.rb
@@ -26,7 +26,9 @@ Then('I should receive an invalid argument migration from HTTP') do
 end
 
 Then('I should receive a timed out migration from HTTP') do
-  expect(@response).to be_a(RestClient::Exceptions::ReadTimeout)
+  expect(@response).to(
+    be_a(RestClient::Exceptions::ReadTimeout).or(be_a(Timeout::Error))
+  )
 end
 
 def request_with_http(table)


### PR DESCRIPTION
## What

- Accept either the HTTP client's read-timeout exception or Ruby's generic timeout exception in the migration timeout scenario.

## Why

- The fault-injection scenario can surface `Timeout::Error` with the current Ruby HTTP stack, so the feature assertion should recognize the equivalent observable timeout outcome.

## Testing

- `make -C test lint` - passed
- `make features feature=features/v1/transport/http/migrate.feature` - passed
- Full CI lint and security checks were not run locally; the change is limited to the Ruby feature-harness timeout assertion.

AI-assisted-by: [Codex](https://openai.com/codex/)
